### PR TITLE
remove project name from test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -10,8 +10,6 @@ function finish {
 }
 trap finish EXIT
 
-export COMPOSE_PROJECT_NAME=conjurdev
-
 docker-compose up -d conjur pg
 
 sleep 10


### PR DESCRIPTION
setting `COMPOSE_PROJECT_NAME` can cause a conflict if multiple branches are built on the same executor. removing this line to prevent this conflict.
  
[Jenkins build](https://jenkins.conjur.net/job/conjurinc--conjur-service-broker/job/fix-test-conflict/)