### PR TITLE
CONJ-4667 Conjur Service Broker has health check

### DIFF
--- a/bin/health-check.rb
+++ b/bin/health-check.rb
@@ -7,7 +7,7 @@ require 'conjur_client'
 begin
   conjur_api = ConjurClient.api
   conjur_api.resources limit: 5
+  puts "Successfully validated Conjur credentials."
 rescue
-  puts "Error: There is an issue with your Conjur configuration. Please verify that the credentials are correct and try again."
-  exit 1
+  raise "Error: There is an issue with your Conjur configuration. Please verify that the credentials are correct and try again."
 end

--- a/bin/start-service-broker.sh
+++ b/bin/start-service-broker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash -ex
+
+./bin/health-check.rb
+./bin/rails s -b 0.0.0.0

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 ---
 applications:
 - name: conjur-service-broker
-  command: ./bin/rails s -b 0.0.0.0
+  command: ./bin/start-service-broker.sh


### PR DESCRIPTION
Add health check to run on startup and verify that the SB is able to communicate with the Conjur server

[Jenkins build](https://jenkins.conjur.net/job/conjurinc--conjur-service-broker/job/CONJ-4667-startup-health-check/)
[Jira story](https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJ-4667)

How to test:
- Install SB in PCF Dev (following guidelines in `local` [CF demo](https://github.com/conjurinc/cloudfoundry-conjur-demo through the `cf start` step)
- Run `cf logs conjur-service-broker --recent` to see that it actually ran the health check before starting the rails server and output **Successfully validated Conjur credentials.**
- Change the API key to an invalid value in the SB env and `cf restage`, and watch it fail (for failure info, see `cf logs conjur-service-broker --recent` again)
- Reset the API key to a valid value and change the `bin/start-service-broker.sh` script so that the rails server line reads `./bin/rails s -b 0.0.0.0 -c missing_file.yml` (or provide some other random non-existent filename). Run `cf push` and watch the rails server fail, even as the health check passes (you can verify by viewing `cf logs conjur-service-broker --recent` again)