### PR TITLE
CONJ-4693 - SB returns Conjur version on bind

### DIFF
--- a/app/models/service_binding.rb
+++ b/app/models/service_binding.rb
@@ -40,7 +40,8 @@ class ServiceBinding
       account: ConjurClient.account,
       appliance_url: ConjurClient.appliance_url,
       authn_login: host,
-      authn_api_key: result.created_roles.values.first['api_key']
+      authn_api_key: result.created_roles.values.first['api_key'],
+      version: ConjurClient.version
     }
   end
 

--- a/features/bind.feature
+++ b/features/bind.feature
@@ -22,6 +22,7 @@ Feature: Binding
     And the JSON at "credentials/authn_login" should be a string
     And the JSON at "credentials/authn_login" should include "pcf/"
     And the JSON at "credentials/authn_api_key" should be a string
+    And the JSON at "credentials/version" should be a string
     And the JSON has valid conjur credentials
 
   Scenario: Bind resource
@@ -44,6 +45,7 @@ Feature: Binding
     And the JSON at "credentials/appliance_url" should be "http://conjur_5"
     And the JSON at "credentials/authn_login" should be a string
     And the JSON at "credentials/authn_api_key" should be a string
+    And the JSON at "credentials/version" should be a string
     And the JSON has valid conjur credentials
 
   Scenario: Bind resource with invalid body - missing key

--- a/lib/conjur_client.rb
+++ b/lib/conjur_client.rb
@@ -30,6 +30,10 @@ class ConjurClient
     def ssl_cert
       ENV['CONJUR_SSL_CERTIFICATE']
     end
+
+    def version
+      ENV['CONJUR_VERSION'] || '5'
+    end
   end
 
   def api


### PR DESCRIPTION
Added Conjur version to the creds returned on bind so that the version will be accessible to the buildpack.

[Jenkins build](https://jenkins.conjur.net/job/cyberark--conjur-service-broker/job/CONJ-4693-SB-returns-version-on-bind/)
[Jira story](https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJ-4693)