### PR TITLE
36 - Service broker correctly handles empty `CONJUR_SSL_CERTIFICATE` env var

### DIFF
--- a/lib/conjur_client.rb
+++ b/lib/conjur_client.rb
@@ -28,7 +28,7 @@ class ConjurClient
     end
   
     def ssl_cert
-      ENV['CONJUR_SSL_CERTIFICATE'] unless ENV['CONJUR_SSL_CERTIFICATE'].to_s.empty?
+      ENV['CONJUR_SSL_CERTIFICATE'] unless ENV['CONJUR_SSL_CERTIFICATE'].blank?
     end
 
     def version

--- a/lib/conjur_client.rb
+++ b/lib/conjur_client.rb
@@ -28,7 +28,7 @@ class ConjurClient
     end
   
     def ssl_cert
-      ENV['CONJUR_SSL_CERTIFICATE']
+      ENV['CONJUR_SSL_CERTIFICATE'] unless ENV['CONJUR_SSL_CERTIFICATE'].to_s.empty?
     end
 
     def version


### PR DESCRIPTION
Closes #36 

This update addresses an issue where the SB was attempting to parse an empty `CONJUR_SSL_CERTIFICATE` env var.