### PR TITLE
CONJ-4597 - Update README to recommend Host for SB configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,35 +1,28 @@
-The Conjur Service Broker makes it easy for you to secure credentials used by applications deployed in Cloud Foundry (CF) with CyberArk Conjur. Using the Conjur Service Broker, your CF applications will automatically assume a Conjur identity on deploy that will enable them to securely access secret values stored in Conjur.
+The Conjur Service Broker makes it easy for you to secure credentials used by applications deployed in Cloud Foundry (CF) with CyberArk Conjur. Using the Conjur Service Broker, your CF applications will automatically assume a Conjur Host identity on deploy that will enable them to securely access secret values stored in Conjur.
 
 You will need to have an existing Conjur installation in order to use the Conjur Service Broker; for more information about installing Conjur, please visit [conjur.org](http://conjur.org) or check out our [GitHub repository](https://github.com/cyberark/conjur).
 
 The Conjur Service Broker is an implementation of the [Open Service Broker API](https://www.openservicebrokerapi.org/) (version 2.13).
 
-## Getting Started
+## Installation Instructions
 
-### Installing the Conjur Buildpack
+The instructions that follow will guide you through installing the Conjur Service Broker
+and the Conjur Buildpack. The [Conjur Buildpack](https://github.com/cyberark/cloudfoundry-conjur-buildpack)
+is a decorator buildpack that installs [Summon](https://cyberark.github.io/summon/)
+on application start, and uses Summon to securely inject secret values into your
+application's environment. Using the Conjur Buildpack is a convenient way to
+securely deliver the secrets that your application needs.
 
-The Conjur Buildpack uses [Summon](https://cyberark.github.io/summon/) to load secrets into the environment of CF-deployed applications based on the app's `secrets.yml` file. The Conjur Buildpack is a decorator buildpack, and requires the meta-buildpack to work properly.
-
-**Before you begin, ensure you are logged into your CF deployment via the CF CLI.**
-
-Install the [meta-buildpack](https://github.com/cf-platform-eng/meta-buildpack):
-```
-git clone git@github.com:cf-platform-eng/meta-buildpack
-cd meta-buildpack
-./build
-./upload
-```
-
-Install the [Conjur buildpack](https://github.com/conjurinc/cloudfoundry-conjur-buildpack):
-```
-git clone git@github.com:conjurinc/cloudfoundry-conjur-buildpack
-cd cloudfoundry-conjur-buildpack
-./upload.sh
-```
+The Conjur Buildpack and Conjur Service Broker should be installed by an admin
+Cloud Foundry user. If you follow the instructions below, your CF installation
+will be configured so that CF users in any org / space will be able to see the
+Conjur service listing when they run `cf marketplace`. For more information on how
+to use the Conjur Service Broker when deploying applications, see the
+[usage instructions](#service-broker-usage).
 
 ### Installing the Conjur Service Broker
 
-Once you've installed both buildpacks, you can load the Conjur Service Broker into your CF deployment and configure it for use with your external Conjur instance.
+**Before you begin, ensure you are logged into your CF deployment via the CF CLI.**
 
 Begin by pushing the Service Broker application to CF:
 ```
@@ -48,10 +41,10 @@ To configure the Service Broker to communicate with your external Conjur instanc
 - `CONJUR_VERSION`: the version of your Conjur instance (`4` or `5`); defaults to 5
 - `CONJUR_ACCOUNT`: the account name for the Conjur instance you are connecting to
 - `CONJUR_APPLIANCE_URL`: the URL of the Conjur appliance instance you are connecting to
-- `CONJUR_POLICY`: the policy namespace where new hosts should be added - the Conjur account specified in `CONJUR_AUTHN_LOGIN` needs `create` and `update` privilege on this policy.
-  - The `CONJUR_POLICY` is optional, but is strongly recommended. By default, if this value is not specified, hosts will be added to the `root` Conjur policy, and the Conjur account that the Service Broker uses to manage the hosts will need `create` and `update` privileges on the `root` Conjur policy.
-- `CONJUR_AUTHN_LOGIN`: the username of a Conjur user with `create` and `update` privileges on `CONJUR_POLICY`. This account will be used to add and remove hosts from the Conjur policy as apps are deployed to or removed from PCF.
-- `CONJUR_AUTHN_API_KEY`: the API Key of the Conjur user whose username you have provided in `CONJUR_AUTHN_LOGIN`
+- `CONJUR_POLICY`: the Policy where new Hosts should be added - the Conjur account specified in `CONJUR_AUTHN_LOGIN` needs `create` and `update` privilege on this Policy.
+  - The `CONJUR_POLICY` is optional, but is strongly recommended. By default, if this value is not specified, Hosts will be added to the `root` Conjur policy, and the Conjur account that the Service Broker uses to manage the Hosts will need `create` and `update` privileges on the `root` Conjur policy.
+- `CONJUR_AUTHN_LOGIN`: the identity of a Conjur Host (of the form `host/host-id`) with `create` and `update` privileges on `CONJUR_POLICY`. This account will be used to add and remove Hosts from Conjur policy as apps are deployed to or removed from PCF.
+- `CONJUR_AUTHN_API_KEY`: the API Key of the Conjur Host whose identity you have provided in `CONJUR_AUTHN_LOGIN`
 - `CONJUR_SSL_CERTIFICATE`: the x509 certificate that was created when Conjur was initiated; this is required for v4 Conjur, but is optional otherwise. If the certificate is stored in a PEM file, you can load it into a local environment variable by calling `export CONJUR_SSL_CERTIFICATE="$(cat tmp/conjur.pem)"`
 
 _Note:_ If you are using v4 Conjur, the Service Broker requires your `CONJUR_POLICY` to have a Host Factory called `CONJUR_POLICY-apps`. For example, if your `CONJUR_POLICY` is `cf`, you can add a Host Factory by updating your policy file to include the following:
@@ -94,27 +87,76 @@ cf start conjur-service-broker
 and register it with the same Basic Auth credentials specified in your environment variables:
 ```
 APP_URL="http://`cf app conjur-service-broker | grep -E -w 'urls:|routes:' | awk '{print $2}'`"
-cf create-service-broker conjur-service-broker "[username value]" "[password value]" $APP_URL --space-scoped
+cf create-service-broker conjur-service-broker "[username value]" "[password value]" $APP_URL
 ```
 When the Service Broker application is started, it will run a health check that validates its connection to your Conjur instance, including checking that the Host Factory exists if you are using Conjur version 4.
 
-Finally, create a service instance under the `community` plan:
+To make the Conjur service listing available in the marketplace in all orgs and spaces, run
+```
+cf enable-service-access cyberark-conjur
+```
+
+If you have reached this point, the Conjur Service Broker has been successfully
+deployed to your Cloud Foundry installation.
+
+### Installing the Conjur Buildpack
+
+The Conjur Buildpack uses [Summon](https://cyberark.github.io/summon/) to load secrets into the environment of CF-deployed applications based on the app's `secrets.yml` file. The Conjur Buildpack is a decorator buildpack, and requires the meta-buildpack to work properly.
+
+Install the [meta-buildpack](https://github.com/cf-platform-eng/meta-buildpack):
+```
+git clone git@github.com:cf-platform-eng/meta-buildpack
+cd meta-buildpack
+./build
+./upload
+```
+
+Install the [Conjur buildpack](https://github.com/conjurinc/cloudfoundry-conjur-buildpack):
+```
+git clone git@github.com:conjurinc/cloudfoundry-conjur-buildpack
+cd cloudfoundry-conjur-buildpack
+./upload.sh
+```
+
+## Service Broker Usage
+
+Once the Service Broker is installed, you should see the service listing from any
+org / space:
+```
+$ cf marketplace
+Getting services from marketplace in org cyberark-conjur-org / space cyberark-conjur-space as admin...
+OK
+
+service             plans                  description
+cyberark-conjur     community              An open source security service that provides secrets management, machine-identity based authorization, and more.
+
+TIP:  Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service.
+```
+
+When you are ready to use the Conjur Service Broker, you can create a Conjur
+service instance under the `community` plan in the org / space where you will be
+deploying your application:
 ```
 cf create-service cyberark-conjur community conjur
 ```
 
-### Service Broker Usage
+### Create a `secrets.yml` File
 
-#### Creating a `secrets.yml` File
+To leverage the Conjur Buildpack so that secret values will automatically be
+injected into your application's environment at runtime, a `secrets.yml` file is
+required. The `secrets.yml` file gives a mapping of **environment variable name**
+to a **location where a secret is stored in Conjur**. For more information about
+creating this file, [see the Summon documentation](https://cyberark.github.io/summon/#secrets.yml).
 
-To use the Conjur Service Broker with a CF-deployed application, a `secrets.yml` file is required. The `secrets.yml` file gives a mapping of **environment variable name** to a **location where a secret is stored in Conjur**. For more information about creating this file, [see the Summon documentation](https://cyberark.github.io/summon/#secrets.yml).
+### Bind Your Application to the Conjur Service
 
-#### Binding Your Application to the Conjur Service
-To bind your application to the Conjur Service Instance, you can either run
+Binding your application to the `conjur` service instance automatically gives it
+a unique Host identity in Conjur. To bind your application to the `conjur` service
+instance, you can either run
 ```
 cf bind-service my-app conjur
 ```
-or you can update the application's deployment manifest to include the Conjur Service:
+or you can update the application's deployment manifest to reference the `conjur` service:
 ```
 ---
 applications:
@@ -122,12 +164,24 @@ applications:
   services:
   - conjur
 ```
-In order to update the environment to load the secrets using the Conjur Service, you will need to restage the app:
-```
-cf restage my-app
-```
 
-The secrets are now available to be used by the application, but are not visible when you run `cf env my-app` or if you `cf ssh my-app` and run `printenv`.
+### Update Conjur Policy to Privilege Your Application
+
+Once your app has a Host identity in Conjur, you can update Conjur policy to add
+entitlements for the app to access secret values in Conjur. The host identity of
+the application is stored in the `authn_login` field in the `cyberark-conjur`
+credentials in the application's environment, and might look something like
+`host/cf/0299a19d-7de4-4e98-89f6-372ac7c0521f` (for example, if your `CONJUR_POLICY`
+was set to `cf`).
+
+### Run Your Application
+
+Now that your application is privileged to access the secrets it needs in Conjur,
+start or restage the app so that the Conjur Buildpack can inject the secret values
+into the running application's environment.
+
+The secrets are now available to be used by the application, but are not visible
+when you run `cf env my-app` or if you `cf ssh my-app` and run `printenv`.
 
 ## Development
 


### PR DESCRIPTION
This PR updates the README for clarity, to be consistent with our other docs / tutorials, and to include recommendations that a Conjur Host identity is used for the Service Broker configuration.