### PR TITLE
CONJ-4776 SB adds annotation to hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+If the service broker host identity has a `platform` annotation in Conjur, hosts added to policy by the service broker will include an annotation for the platform also.
+
 ## [0.2.0] - 2018-02-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-If the service broker host identity has a `platform` annotation in Conjur, hosts added to policy by the service broker will include an annotation for the platform also.
+If the service broker host identity has a `platform` annotation in Conjur, hosts added to policy by the service broker will also include an annotation for the platform.
 
 ## [0.2.0] - 2018-02-12
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,17 @@ To configure the Service Broker to communicate with your external Conjur instanc
 - `CONJUR_POLICY`: the Policy where new Hosts should be added - the Conjur account specified in `CONJUR_AUTHN_LOGIN` needs `create` and `update` privilege on this Policy.
   - The `CONJUR_POLICY` is optional, but is strongly recommended. By default, if this value is not specified, Hosts will be added to the `root` Conjur policy, and the Conjur account that the Service Broker uses to manage the Hosts will need `create` and `update` privileges on the `root` Conjur policy.
 - `CONJUR_AUTHN_LOGIN`: the identity of a Conjur Host (of the form `host/host-id`) with `create` and `update` privileges on `CONJUR_POLICY`. This account will be used to add and remove Hosts from Conjur policy as apps are deployed to or removed from PCF.
+
+  If you are using Enterprise Conjur, you will want to add an annotation on the Service Broker Host in policy to indicate which platform the Service Broker will be used on. The policy you load may look something like:
+  ```
+  - !host
+    id: cf-service-broker
+    annotations:
+      platform: cloudfoundry
+  ```
+  You may elect to set `platform` to `cloudfoundry` or to `pivotalcloudfoundry`, for example. This annotation will be used to set annotations on Hosts added by the Service Broker, so that they will show in the Conjur UI with the appropriate platform logo.
+
+  Note: the `CONJUR_AUTHN_LOGIN` value for the Host created in policy above is `host/cf-service-broker`.
 - `CONJUR_AUTHN_API_KEY`: the API Key of the Conjur Host whose identity you have provided in `CONJUR_AUTHN_LOGIN`
 - `CONJUR_SSL_CERTIFICATE`: the x509 certificate that was created when Conjur was initiated; this is required for v4 Conjur, but is optional otherwise. If the certificate is stored in a PEM file, you can load it into a local environment variable by calling `export CONJUR_SSL_CERTIFICATE="$(cat tmp/conjur.pem)"`
 

--- a/app/models/service_binding.rb
+++ b/app/models/service_binding.rb
@@ -61,10 +61,10 @@ class ServiceBinding
         create_token(Time.now + 1.hour)
 
     options =
-      if ConjurClient.platform
-        { annotations: "{ \"#{ConjurClient.platform}\": \"true\" }" }
-      else
+      if ConjurClient.platform.to_s.empty?
         {}
+      else
+        { annotations: { "#{ConjurClient.platform}": "true" } }
       end
 
     host = Conjur::API.host_factory_create_host(hf_token, host_id, options)
@@ -78,16 +78,16 @@ class ServiceBinding
   end
 
   def template_create
-    if !ConjurClient.platform.to_s.empty?
+    if ConjurClient.platform.to_s.empty?
+      """
+      - !host #{@binding_id}
+      """
+    else
       """
       - !host
         id: #{@binding_id}
         annotations:
           #{ConjurClient.platform}: true
-      """
-    else
-      """
-      - !host #{@binding_id}
       """
     end
   end

--- a/ci/configure_v5.sh
+++ b/ci/configure_v5.sh
@@ -1,3 +1,9 @@
 #!/bin/bash -ex
 
 docker-compose exec -T conjur_5 conjurctl wait -r 30 -p 80
+
+api_key=$(docker-compose exec -T conjur_5 bash -c 'rails r "puts Role[%Q{cucumber:user:admin}].api_key" 2>/dev/null')
+export CONJUR_AUTHN_API_KEY="$api_key"
+
+# load the pcf policy for the non-empty CONJUR_POLICY test
+docker-compose run --rm --entrypoint bash client -c "conjur policy load root /app/ci/policy.yml"

--- a/ci/policy.yml
+++ b/ci/policy.yml
@@ -1,12 +1,14 @@
-- !user
-  id: pcf-admin
+- !host
+  id: cf-service-broker
+  annotations:
+    platform: cloudfoundry
 
 - !group
-  id: pcf-admin-group
+  id: cf-admin-group
 
 - !grant
-  role: !group pcf-admin-group
-  member: !user pcf-admin
+  role: !group cf-admin-group
+  member: !host cf-service-broker
 
 - !layer apps
 
@@ -15,11 +17,11 @@
   layers: [ !layer apps ]
   
 - !policy
-  id: pcf
-  owner: !group pcf-admin-group
+  id: cf
+  owner: !group cf-admin-group
   body:
-  - !layer pcf-apps
+  - !layer cf-apps
     
   - !host-factory
-    id: pcf-apps
-    layers: [ !layer pcf-apps ]
+    id: cf-apps
+    layers: [ !layer cf-apps ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
     build: ./
     environment:
       CONJUR_ACCOUNT: cucumber
-      CONJUR_AUTHN_LOGIN: admin
+      CONJUR_AUTHN_LOGIN: host/cf-service-broker
       CONJUR_APPLIANCE_URL:
       SECURITY_USER_NAME: TEST_USER_NAME
       SECURITY_USER_PASSWORD: TEST_USER_PASSWORD
@@ -114,5 +114,14 @@ services:
   tests:
     image: conjur-service-broker
     build: ./
+    environment:
+      CONJUR_ACCOUNT: cucumber
+      CONJUR_AUTHN_LOGIN: admin
+      CONJUR_APPLIANCE_URL:
+      SECURITY_USER_NAME: TEST_USER_NAME
+      SECURITY_USER_PASSWORD: TEST_USER_PASSWORD
+      CONJUR_AUTHN_API_KEY:
+      CONJUR_SSL_CERTIFICATE:
+      CONJUR_VERSION:
     volumes:
       - "./:/app"

--- a/features/bind.feature
+++ b/features/bind.feature
@@ -23,7 +23,7 @@ Feature: Binding
     And the JSON at "credentials/ssl_certificate" should be a string
     And the JSON has valid conjur credentials
 
-  Scenario: Bind resource with pcf policy configured
+  Scenario: Bind resource with cf policy configured
     Given I use a service broker with a non-root policy
     When I make a bind request with body:
     """
@@ -40,14 +40,16 @@ Feature: Binding
     }
     """
     Then the HTTP response status code is "201"
+    And I keep the JSON response as "BIND_RESPONSE"
     And the JSON at "credentials/account" should be "cucumber"
     And the JSON at "credentials/appliance_url" should be a string
     And the JSON at "credentials/authn_login" should be a string
-    And the JSON at "credentials/authn_login" should include "pcf/"
+    And the JSON at "credentials/authn_login" should include "cf/"
     And the JSON at "credentials/authn_api_key" should be a string
     And the JSON at "credentials/version" should be a Fixnum
     And the JSON at "credentials/ssl_certificate" should be a string
     And the JSON has valid conjur credentials
+    And the host in "BIND_RESPONSE" has annotation "'cloudfoundry': 'true'" in Conjur
 
   Scenario: Bind resource with invalid body - missing key
     When I make a bind request with body:
@@ -91,7 +93,7 @@ Feature: Binding
     Then the HTTP response status code is "409"
     And the JSON should be {}
 
-  Scenario: Bind resource with existing ID with pcf policy configured
+  Scenario: Bind resource with existing ID with cf policy configured
     Given I use a service broker with a non-root policy
     When I make a bind request with an existing binding_id and body:
     """

--- a/features/step_definitions/response_steps.rb
+++ b/features/step_definitions/response_steps.rb
@@ -19,16 +19,28 @@ Then(/^the singular plan is named "([^"]*)"$/) do |expected_plan|
 end
 
 And(/^the JSON from "([^"]*)" has (in)?valid conjur credentials$/) do |memory_id, negate|
-  response_json = JsonSpec.remember("%{#{memory_id}}")
+  store_json_response(memory_id)
 
   if negate
-    expect{ conjur_authenticate_from_json(response_json) }.to raise_error(RestClient::Unauthorized)
+    expect{ conjur_authenticate_from_json(@response_json) }.to raise_error(RestClient::Unauthorized)
   else
-    expect{ conjur_authenticate_from_json(response_json) }.not_to raise_error
+    expect{ conjur_authenticate_from_json(@response_json) }.not_to raise_error
   end
 end
 
-
 And(/^the JSON has valid conjur credentials$/) do
   expect{ conjur_authenticate_from_json(last_json) }.not_to raise_error
+end
+
+And(/^the host in "([^"]*)" has annotation "([^"]*)" in Conjur$/) do |memory_id, annotation|
+  store_json_response(memory_id)
+  annotation_hash = JSON.parse("{ #{annotation.gsub("'", '"')} }")
+
+  has_annotation = false
+  host_annotations.each do |host_annotation|
+    host_annotation_hash = { "#{host_annotation['name']}" => host_annotation['value'] }
+    has_annotation = true if host_annotation_hash == annotation_hash
+  end
+
+  expect(has_annotation).to be true
 end

--- a/features/support/world.rb
+++ b/features/support/world.rb
@@ -1,5 +1,6 @@
 require 'rest_client'
 require 'conjur-api'
+require 'conjur_client'
 
 module ServiceBrokerWorld
   def last_json
@@ -76,14 +77,14 @@ module ServiceBrokerWorld
     end
   end
 
-  def conjur_authenticate_from_json(response_json)
-    account = parse_json(response_json, 'credentials/account')
-    appliance_url = parse_json(response_json, 'credentials/appliance_url')
-    login = parse_json(response_json, 'credentials/authn_login')
-    api_key = parse_json(response_json, 'credentials/authn_api_key')
-    version = parse_json(response_json, 'credentials/version')
-    ssl_cert = parse_json(response_json, 'credentials/ssl_certificate')
-    
+  def conjur_authenticate_from_json auth_json
+    account = parse_json(auth_json, 'credentials/account')
+    appliance_url = parse_json(auth_json, 'credentials/appliance_url')
+    login = parse_json(auth_json, 'credentials/authn_login')
+    api_key = parse_json(auth_json, 'credentials/authn_api_key')
+    version = parse_json(auth_json, 'credentials/version')
+    ssl_cert = parse_json(auth_json, 'credentials/ssl_certificate')
+
     Conjur.with_configuration Conjur::Configuration.new(
       account: account,
       appliance_url: appliance_url,
@@ -93,6 +94,19 @@ module ServiceBrokerWorld
       Conjur.configuration.apply_cert_config!
       Conjur::API.authenticate(login, api_key)
     end
+  end
+
+  def store_json_response memory_id
+    @response_json = JsonSpec.remember("%{#{memory_id}}")
+  end
+
+  def host_id
+    parse_json(@response_json, 'credentials/authn_login').gsub(/host\//, "")
+  end
+
+  def host_annotations
+    host = ConjurClient.api.resource("#{ConjurClient.account}:host:#{host_id}")
+    JSON.parse(host.attributes["annotations"].to_json)
   end
 
   private

--- a/lib/conjur_client.rb
+++ b/lib/conjur_client.rb
@@ -30,6 +30,10 @@ class ConjurClient
     def authn_login
       ENV['CONJUR_AUTHN_LOGIN']
     end
+
+    def login_host_id
+      authn_login.sub /host\//, "" if authn_login.include? "host"
+    end
   
     def appliance_url
       ENV['CONJUR_APPLIANCE_URL']
@@ -41,6 +45,17 @@ class ConjurClient
   
     def ssl_cert
       ENV['CONJUR_SSL_CERTIFICATE'] unless ENV['CONJUR_SSL_CERTIFICATE'].blank?
+    end
+
+    def platform
+      platform_annotation = ""
+      if authn_login.include? "host"
+        host = api.resource("#{account}:host:#{login_host_id}")
+        JSON.parse(host.attributes["annotations"].to_json).each do |annotation|
+          platform_annotation = annotation["value"] if annotation["name"] == "platform"
+        end
+      end
+      return platform_annotation
     end
   end
 

--- a/lib/conjur_client.rb
+++ b/lib/conjur_client.rb
@@ -22,19 +22,19 @@ class ConjurClient
     def account
       ENV['CONJUR_ACCOUNT']
     end
-  
+
     def authn_api_key
       ENV['CONJUR_AUTHN_API_KEY']
     end
-  
+
     def authn_login
       ENV['CONJUR_AUTHN_LOGIN']
     end
 
     def login_host_id
-      authn_login.sub /host\//, "" if authn_login.include? "host"
+      authn_login.sub /^host\//, "" unless authn_login.index(/^host\//).nil?
     end
-  
+
     def appliance_url
       ENV['CONJUR_APPLIANCE_URL']
     end
@@ -42,19 +42,20 @@ class ConjurClient
     def policy
       ENV['CONJUR_POLICY'] || 'root'
     end
-  
+
     def ssl_cert
       ENV['CONJUR_SSL_CERTIFICATE'] unless ENV['CONJUR_SSL_CERTIFICATE'].blank?
     end
 
     def platform
       platform_annotation = ""
-      if authn_login.include? "host"
+      if !login_host_id.nil?
         host = api.resource("#{account}:host:#{login_host_id}")
         JSON.parse(host.attributes["annotations"].to_json).each do |annotation|
           platform_annotation = annotation["value"] if annotation["name"] == "platform"
         end
       end
+      
       return platform_annotation
     end
   end
@@ -69,7 +70,7 @@ class ConjurClient
 
     Conjur.configuration.apply_cert_config!
 
-    Conjur::API.new_from_key ConjurClient.authn_login, 
+    Conjur::API.new_from_key ConjurClient.authn_login,
                              ConjurClient.authn_api_key
   end
 end

--- a/spec/models/service_binding_spec.rb
+++ b/spec/models/service_binding_spec.rb
@@ -11,15 +11,17 @@ describe ServiceBinding do
     end
     
     it "uses the Conjur API to load policy to delete the host" do
-      expect_any_instance_of(Conjur::API).
-        to receive(:load_policy).
-        with("root",
-    """
-    - !delete
-      record: !host binding_id
-    """,
-        method: :patch
-        )
+      if ENV['CONJUR_VERSION'] == 5
+        expect_any_instance_of(Conjur::API).
+          to receive(:load_policy).
+          with("root",
+      """
+      - !delete
+        record: !host binding_id
+      """,
+          method: :patch
+          )
+      end
       expect(host).to receive(:rotate_api_key)
 
       ServiceBinding.new("service_id", "binding_id").delete

--- a/test.sh
+++ b/test.sh
@@ -21,6 +21,24 @@ function startConjur() {
   docker-compose up -d pg conjur_4 conjur_5
 }
 
+function runTests() {
+  docker-compose up -d conjur-service-broker service-broker-bad-url service-broker-bad-key
+
+  export CONJUR_POLICY=cf
+  if [[ $1 -eq 4 ]]
+  then
+    export CONJUR_AUTHN_API_KEY="$(docker-compose exec -T conjur_4 su conjur -c "conjur-plugin-service authn env RAILS_ENV=appliance rails r \"puts User['admin'].api_key\" 2>/dev/null")"
+  else
+    export CONJUR_AUTHN_API_KEY="$(docker-compose exec -T conjur_5 bash -c 'rails r "puts Role[%Q{cucumber:host:cf-service-broker}].api_key" 2>/dev/null')"
+  fi
+
+  docker-compose up -d service-broker-alt-policy
+
+  echo "Running tests"
+  echo "---"
+  docker-compose run -e CONJUR_AUTHN_API_KEY=$api_key tests ci/test.sh
+}
+
 function runTests5() {
   echo "Waiting for Conjur v5 to come up, and configuring it..."
   ./ci/configure_v5.sh
@@ -29,13 +47,10 @@ function runTests5() {
   export CONJUR_APPLIANCE_URL=http://conjur_5
   export CONJUR_SSL_CERTIFICATE=""
 
-  local api_key=$(docker-compose exec -T conjur_5 bash -c 'rails r "puts Role[%Q{cucumber:user:admin}].api_key" 2>/dev/null')
+  api_key=$(docker-compose exec -T conjur_5 bash -c 'rails r "puts Role[%Q{cucumber:user:admin}].api_key" 2>/dev/null')
   export CONJUR_AUTHN_API_KEY="$api_key"
 
-  # load the pcf policy for the non-empty CONJUR_POLICY test
-  docker-compose run --rm --entrypoint bash client -c "conjur policy load root /app/ci/policy.yml"
-
-  runTests
+  runTests 5
 }
 
 function cleanUpServiceBrokers() {
@@ -51,19 +66,10 @@ function runTests4() {
   export CONJUR_APPLIANCE_URL=https://conjur_4/api
   export CONJUR_SSL_CERTIFICATE="$(cat tmp/conjur.pem)"
 
-  local api_key=$(docker-compose exec -T conjur_4 su conjur -c "conjur-plugin-service authn env RAILS_ENV=appliance rails r \"puts User['admin'].api_key\" 2>/dev/null")
+  api_key=$(docker-compose exec -T conjur_4 su conjur -c "conjur-plugin-service authn env RAILS_ENV=appliance rails r \"puts User['admin'].api_key\" 2>/dev/null")
   export CONJUR_AUTHN_API_KEY="$api_key"
 
-  runTests
-}
-
-function runTests() {
-  export CONJUR_POLICY=pcf
-  docker-compose up -d conjur-service-broker service-broker-bad-url service-broker-bad-key service-broker-alt-policy
-
-  echo "Running tests"
-  echo "---"
-  docker-compose run tests ci/test.sh
+  runTests 4
 }
 
 main

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,7 @@ function runTests() {
   export CONJUR_POLICY=cf
   if [[ $1 -eq 4 ]]
   then
-    export CONJUR_AUTHN_API_KEY="$(docker-compose exec -T conjur_4 su conjur -c "conjur-plugin-service authn env RAILS_ENV=appliance rails r \"puts User['admin'].api_key\" 2>/dev/null")"
+    export CONJUR_AUTHN_API_KEY="$(docker-compose exec -T conjur_4 su conjur -c "conjur-plugin-service authn env RAILS_ENV=appliance rails r \"puts User['host/cf-service-broker'].api_key\" 2>/dev/null")"
   else
     export CONJUR_AUTHN_API_KEY="$(docker-compose exec -T conjur_5 bash -c 'rails r "puts Role[%Q{cucumber:host:cf-service-broker}].api_key" 2>/dev/null')"
   fi


### PR DESCRIPTION
This PR updates the service broker to check its host identity (`ConjurClient.authn_login`) for an annotation of the form `platform: [platform-name]`, where `platform-name` might be `cloudfoundry`, `pivotalcloudfoundry`, `kubernetes`, or `openshift`.

If the SB host identity has a `platform` annotation, then a `[platform-name]: true` annotation will be added to all hosts added to Conjur policy by the service broker.

Only the `alt-policy-name` bind test uses the host identity with its platform annotation in the SB config, so that test was updated to confirm that the host the SB added on bind has the appropriate annotation in Conjur.

[Jenkins run](https://jenkins.conjur.net/job/cyberark--conjur-service-broker/job/CONJ-4776-SB-adds-annotation-to-hosts/)
[Jira story](https://ca-il-jira.il.cyber-ark.com:8443/browse/CONJ-4776)