### PR TITLE
Update dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,9 +5,9 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
-gem 'conjur-api', '~> 5.1.0'
-gem 'activesupport', '~> 5.2.0'
-gem 'railties', '~> 5.2.0'
+gem 'conjur-api', '~> 5.3.1'
+gem 'activesupport', '~> 5.2.1'
+gem 'railties', '~> 5.2.1'
 gem 'json-schema', '~> 2.8'
 
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (5.2.0)
-      actionview (= 5.2.0)
-      activesupport (= 5.2.0)
+    actionpack (5.2.1)
+      actionview (= 5.2.1)
+      activesupport (= 5.2.1)
       rack (~> 2.0)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.0)
-      activesupport (= 5.2.0)
+    actionview (5.2.1)
+      activesupport (= 5.2.1)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activesupport (5.2.0)
+    activesupport (5.2.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -38,8 +38,8 @@ GEM
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5)
-    conjur-api (5.1.0)
+    concurrent-ruby (1.1.3)
+    conjur-api (5.3.1)
       activesupport
       rest-client
     contracts (0.16.0)
@@ -63,7 +63,7 @@ GEM
     gherkin (4.1.3)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.0.1)
+    i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
@@ -81,19 +81,19 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.2.2)
+    loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (0.9.0)
-    mime-types (3.1)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
+    mime-types-data (3.2018.0812)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
     multi_json (1.13.1)
     multi_test (0.1.2)
     netrc (0.11.0)
-    nokogiri (1.8.3)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     parslet (1.8.2)
     pry (0.11.3)
@@ -104,20 +104,20 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.2)
     puma (3.11.4)
-    rack (2.0.5)
-    rack-test (1.0.0)
+    rack (2.0.6)
+    rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    railties (5.2.0)
-      actionpack (= 5.2.0)
-      activesupport (= 5.2.0)
+    railties (5.2.1)
+      actionpack (= 5.2.1)
+      activesupport (= 5.2.1)
       method_source
       rake (>= 0.8.7)
-      thor (>= 0.18.1, < 2.0)
+      thor (>= 0.19.0, < 2.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -165,11 +165,11 @@ PLATFORMS
   x86_64-darwin-16
 
 DEPENDENCIES
-  activesupport (~> 5.2.0)
+  activesupport (~> 5.2.1)
   aruba
   byebug
   ci_reporter_rspec (~> 1)
-  conjur-api (~> 5.1.0)
+  conjur-api (~> 5.3.1)
   cucumber (~> 2)
   json-schema (~> 2.8)
   json_spec (~> 1.1.5)
@@ -177,7 +177,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pry-byebug
   puma (~> 3.7)
-  railties (~> 5.2.0)
+  railties (~> 5.2.1)
   rest-client
   rspec (~> 3)
   rspec_junit_formatter
@@ -185,4 +185,4 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
 
 BUNDLED WITH
-   1.16.2
+   1.17.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:9.3
 
   conjur_5:
-    image: cyberark/conjur:0.7.0-stable
+    image: cyberark/conjur:latest
     command: server -a cucumber
     environment:
       DATABASE_URL: postgres://postgres@pg/postgres


### PR DESCRIPTION
Update railties, conjur-api, and activesupport to their latest versions. Update the test suite to test against `cyberark/conjur:latest`.

Connected to https://github.com/conjurinc/appliance/issues/517

[Jenkins build](https://jenkins.conjur.net/job/cyberark--conjur-service-broker/job/update-rack/)