### PR TITLE
Pin rack at version 2.0.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 gem 'conjur-api', '~> 5.3.1'
 gem 'activesupport', '~> 5.2.1'
 gem 'railties', '~> 5.2.1'
+gem 'rack', '~> 2.0.6'
 gem 'json-schema', '~> 2.8'
 
 # Use Puma as the app server

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -177,6 +177,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pry-byebug
   puma (~> 3.7)
+  rack (~> 2.0.6)
   railties (~> 5.2.1)
   rest-client
   rspec (~> 3)


### PR DESCRIPTION
This change ensures rack is above or at version 2.0.6. 

**Note** that this does not change any dependencies, as the correct version was already being pulled from upstream.

Connected to #64 
[Jenkins Build](https://jenkins.conjur.net/job/cyberark--conjur-service-broker/job/64-pin-rack/1/)
