### PR TITLE
Add Host to Org and Space Policy Automatically on Bind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Updated dependencies and Ruby version of Docker image
+- The service broker now adds application Hosts to a Conjur Layer for a Space when the
+  bind context contains `context.organization_guid` and `context.space_guid` (PCF 2.0+)
 
 ## [0.3.2] - 2018-06-26
 

--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,7 @@ group :development, :test do
   gem 'pry-byebug'
   gem 'rspec_junit_formatter'
   gem 'rest-client'
+  gem 'rspec-rails', '~> 3.7'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,14 @@ GEM
     rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
+    rspec-rails (3.7.2)
+      actionpack (>= 3.0)
+      activesupport (>= 3.0)
+      railties (>= 3.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+      rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -182,6 +190,7 @@ DEPENDENCIES
   railties (~> 5.2.1)
   rest-client
   rspec (~> 3)
+  rspec-rails (~> 3.7)
   rspec_junit_formatter
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,7 +1,6 @@
-class UnknownConjurHostError < RuntimeError
-end
+require 'conjur_client'
 
-class ConjurAuthenticationError < RuntimeError
+class UnknownConjurHostError < RuntimeError
 end
 
 class ValidationError < RuntimeError
@@ -11,7 +10,7 @@ class ApplicationController < ActionController::API
   include ActionController::HttpAuthentication::Basic::ControllerMethods
 
   rescue_from UnknownConjurHostError, with: :server_error
-  rescue_from ConjurAuthenticationError, with: :invalid_configuration
+  rescue_from ConjurClient::ConjurAuthenticationError, with: :invalid_configuration
 
   rescue_from ServiceBinding::HostNotFound, with: :host_not_found
   rescue_from ServiceBinding::RoleAlreadyCreated, with: :conflict_error
@@ -40,7 +39,7 @@ class ApplicationController < ActionController::API
     rescue SocketError
       raise UnknownConjurHostError.new "Invalid Conjur host (#{ConjurClient.appliance_url.to_s})"
     rescue RestClient::Unauthorized => e
-      raise ConjurAuthenticationError.new "Conjur authentication failed: #{e.message}"
+      raise ConjurClient::ConjurAuthenticationError.new "Conjur authentication failed: #{e.message}"
     end
   end
 
@@ -83,9 +82,5 @@ class ApplicationController < ActionController::API
   def render_unauthorized
     logger.warn("HTTP Basic: Access Denied")
     render json: {}, status: :unauthorized
-  end
-
-  def v5?
-    ConjurClient.version == 5
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -84,4 +84,8 @@ class ApplicationController < ActionController::API
     logger.warn("HTTP Basic: Access Denied")
     render json: {}, status: :unauthorized
   end
+
+  def v5?
+    ConjurClient.version == 5
+  end
 end

--- a/app/controllers/bind_controller.rb
+++ b/app/controllers/bind_controller.rb
@@ -39,6 +39,6 @@ class BindController < ApplicationController
 
   def use_context?
     # Only create the policy for Conjur V5
-    v5? && org_guid.present? && space_guid.present?
+    ConjurClient.v5? && org_guid.present? && space_guid.present?
   end
 end

--- a/app/models/org_space_policy.rb
+++ b/app/models/org_space_policy.rb
@@ -1,0 +1,75 @@
+require 'conjur_client'
+
+class OrgSpacePolicy
+  class OrgPolicyNotFound < RuntimeError
+  end
+
+  class SpacePolicyNotFound < RuntimeError
+  end
+
+  class SpaceLayerNotFound < RuntimeError
+  end
+
+  class << self
+    def ensure_exists(org_id, space_id)
+      OrgSpacePolicy.new(org_id, space_id).ensure_exists
+    end
+  end
+
+  def initialize(org_id, space_id)
+    @org_id = org_id
+    @space_id = space_id
+  end
+
+  def ensure_exists
+    ensure_org_policy
+    ensure_space_policy
+    ensure_space_layer
+  end
+
+  private
+
+  def ensure_org_policy
+    raise OrgPolicyNotFound unless org_policy.exists?
+  end
+
+  def org_policy
+    conjur_api.resource(org_policy_id)
+  end
+
+  def org_policy_id
+    "#{ConjurClient.account}:policy:#{policy_base}#{@org_id}"
+  end
+
+  def ensure_space_policy
+    raise SpacePolicyNotFound unless space_policy.exists?
+  end
+
+  def space_policy
+    conjur_api.resource(space_policy_id)
+  end
+
+  def space_policy_id
+    "#{ConjurClient.account}:policy:#{policy_base}#{@org_id}/#{@space_id}"
+  end
+
+  def ensure_space_layer
+    raise SpaceLayerNotFound unless space_layer.exists?
+  end
+
+  def space_layer
+    conjur_api.resource(space_layer_id)
+  end
+
+  def space_layer_id
+    "#{ConjurClient.account}:layer:#{policy_base}#{@org_id}/#{@space_id}"
+  end
+
+  def policy_base
+    ConjurClient.policy != 'root' ? ConjurClient.policy + '/' : ''
+  end
+
+  def conjur_api
+    ConjurClient.api
+  end
+end

--- a/ci/integration/policy/entitle-service-broker.yml
+++ b/ci/integration/policy/entitle-service-broker.yml
@@ -1,9 +1,0 @@
-- !permit
-    resource: !policy pcf
-    privileges: [ create, update, read ]
-    roles: !host pcf/service-broker
-
-- !permit
-    resource: !host pcf/service-broker
-    privileges: [ read ]
-    roles: !host pcf/service-broker

--- a/ci/integration/policy/pcf/service-broker.yml
+++ b/ci/integration/policy/pcf/service-broker.yml
@@ -2,3 +2,20 @@
   id: service-broker
   annotations:
     platform: pivotalcloudfoundry
+
+- !group
+  id: ci-admin-group
+
+- !grant
+  role: !group ci-admin-group
+  member: !host service-broker
+
+# Allow host read access to its own resource, to read annotations
+- !permit
+  role: !host service-broker
+  privilege: read
+  resource: !host service-broker
+
+- !policy
+  id: ci
+  owner: !group ci-admin-group

--- a/features/bind.feature
+++ b/features/bind.feature
@@ -1,4 +1,6 @@
 Feature: Binding
+  
+  @conjur-version-5
   Scenario: Bind resource
     When I make a bind request with body:
     """
@@ -23,6 +25,7 @@ Feature: Binding
     And the JSON at "credentials/ssl_certificate" should be a string
     And the JSON has valid conjur credentials
 
+  @conjur-version-5
   Scenario: Bind resource when follower URL is set
     Given I use a service broker with the follower URL environment variable set
     When I make a bind request with body:

--- a/features/integration.feature
+++ b/features/integration.feature
@@ -7,6 +7,7 @@ Feature: Integration Tests
     And I load a secret into Conjur
     And I install the service broker
     And I create a service instance for Conjur
+    And I load policy to define my org and space
 
     When I push the sample app to PCF
     And I privilege the app to access the secret in Conjur

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -17,6 +17,10 @@ Given(/^I create a service instance for Conjur$/) do
   `cf create-service cyberark-conjur community conjur`
 end
 
+Given(/^I load policy to define my org and space$/) do
+  load_space_policy_in_remote_conjur('ci', 'conjur-service-broker')
+end
+
 When(/^I push the sample app to PCF$/) do
   `cf delete hello-world -f`
   Dir.chdir(integration_test_app_dir) do

--- a/features/support/cf_helper.rb
+++ b/features/support/cf_helper.rb
@@ -22,7 +22,7 @@ module CfHelper
     output << `cf set-env conjur-service-broker CONJUR_AUTHN_LOGIN "host/pcf/service-broker"`
     output << `cf set-env conjur-service-broker CONJUR_AUTHN_API_KEY "#{api_key}"`
     output << `cf set-env conjur-service-broker CONJUR_VERSION "5"`
-    output << `cf set-env conjur-service-broker CONJUR_POLICY pcf`
+    output << `cf set-env conjur-service-broker CONJUR_POLICY pcf/ci`
     output << `cf set-env conjur-service-broker CONJUR_SSL_CERTIFICATE "#{ENV['PCF_CONJUR_SSL_CERT']}"`
     
     # Start the service broker and make it available
@@ -32,6 +32,15 @@ module CfHelper
   rescue => ex
     puts output.join("\n")
     raise
+  end
+
+  def org_guid(org_name)
+    `cf org --guid "#{org_name}"`.chomp
+  end
+
+  def space_guid(org_name, space_name)
+    `cf target -o "#{org_name}"`
+    `cf space --guid "#{space_name}"`.chomp
   end
 
   def app_bind_id

--- a/lib/conjur_client.rb
+++ b/lib/conjur_client.rb
@@ -2,6 +2,10 @@ require 'conjur-api'
 require 'openssl'
 
 class ConjurClient
+
+  class ConjurAuthenticationError < RuntimeError
+  end
+
   class << self
     def api
       ConjurClient.new.api
@@ -13,6 +17,10 @@ class ConjurClient
       else
         "#{account}:host_factory:#{policy}/#{policy}-apps"
       end
+    end
+
+    def v5?
+      version == 5
     end
 
     def version

--- a/spec/controllers/bind_controller_spec.rb
+++ b/spec/controllers/bind_controller_spec.rb
@@ -43,13 +43,15 @@ RSpec.describe BindController, type: :request do
     context 'when the app cf context is not present' do
       it "does not ensure the policy structure exists" do
         expect_any_instance_of(OrgSpacePolicy).to_not receive(:ensure_exists)
-        expect_any_instance_of(ServiceBinding).to receive(:create)
+        expect_any_instance_of(ServiceBinding).to receive(:create).and_return('test_creds')
         
         put('/v2/service_instances/test_instance/service_bindings/test_binding', 
           params: legacy_params, headers: headers)
 
         expect(response.content_type).to eq("application/json")
         expect(response).to have_http_status(:created)
+        data = JSON.parse(response.body)
+        expect(data["credentials"]).to eq("test_creds")
       end
     end
 

--- a/spec/controllers/bind_controller_spec.rb
+++ b/spec/controllers/bind_controller_spec.rb
@@ -1,7 +1,87 @@
 require 'spec_helper'
 
-class BindControllerTest < ActionDispatch::IntegrationTest
-  # spec "the truth" do
-  #   assert true
-  # end
+RSpec.describe BindController, type: :request do
+  let(:username) { ENV['SECURITY_USER_NAME'] }
+  let(:password) { ENV['SECURITY_USER_PASSWORD'] }
+
+  let(:legacy_params) do
+    {
+      service_id: 'c024e536-6dc4-45c6-8a53-127e7f8275ab',
+      plan_id: '3a116ac2-fc8b-496f-a715-e9a1b205d05c.community',
+      context: {
+        platform: 'cloudfoundry'
+      },
+      bind_resource: {
+        app_guid: 'test_app'
+      }
+    }
+  end
+
+  let(:params) do 
+    legacy_params.merge({
+      context: {
+        organization_guid: 'test_org',
+        space_guid: 'test_space'
+      }
+    })
+  end
+
+  let(:headers) do
+    {
+      'X-Broker-API-Version' => '2.13',
+      'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+    }
+  end
+
+  describe 'PUT' do
+    before do
+      # Assume V5 unless otherwise set
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return('5')
+    end
+
+    context 'when the app cf context is not present' do
+      it "does not ensure the policy structure exists" do
+        expect_any_instance_of(OrgSpacePolicy).to_not receive(:ensure_exists)
+        expect_any_instance_of(ServiceBinding).to receive(:create)
+        
+        put('/v2/service_instances/test_instance/service_bindings/test_binding', 
+          params: legacy_params, headers: headers)
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:created)
+      end
+    end
+
+    context 'when the app cf context is present' do
+      it "ensures the policy structure exists" do
+        expect_any_instance_of(OrgSpacePolicy).to receive(:ensure_exists)
+        expect_any_instance_of(ServiceBinding).to receive(:create)
+
+        put('/v2/service_instances/test_instance/service_bindings/test_binding', 
+          params: params, headers: headers)
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:created)
+      end
+
+      context 'when using Conjur V4' do
+        before do
+          allow(ENV).to receive(:[]).and_call_original
+          allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return('4')
+        end
+
+        it "does not ensure the policy structure exists" do
+          expect_any_instance_of(OrgSpacePolicy).to_not receive(:ensure_exists)
+          expect_any_instance_of(ServiceBinding).to receive(:create)
+  
+          put('/v2/service_instances/test_instance/service_bindings/test_binding', 
+            params: params, headers: headers)
+  
+          expect(response.content_type).to eq("application/json")
+          expect(response).to have_http_status(:created)
+        end
+      end
+    end
+  end
 end

--- a/spec/models/org_space_policy_spec.rb
+++ b/spec/models/org_space_policy_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe OrgSpacePolicy do
+
+  describe "#ensure_exists" do
+    let(:existent_resource) { double("existent") }
+    let(:nonexistent_resource) { double("non-existent") }
+
+    subject { OrgSpacePolicy.new("org_id", "space_id") }
+    
+    before do
+      allow(existent_resource).to receive(:exists?).and_return(true)
+      allow(nonexistent_resource).to receive(:exists?).and_return(false)
+
+      # By default, assume all resources exist
+      allow_any_instance_of(Conjur::API)
+        .to receive(:resource)
+        .with(any_args)
+        .and_return(existent_resource)
+    end
+
+    context "when resources already exist" do
+      it "does nothing" do
+        subject.ensure_exists
+      end
+    end
+
+    context "when org policy doesn't exist" do
+      before do
+        allow_any_instance_of(Conjur::API)
+          .to receive(:resource)
+          .with('cucumber:policy:org_id').
+          and_return(nonexistent_resource)
+      end
+
+      it "raises an error" do
+        expect { subject.ensure_exists }.to raise_error(OrgSpacePolicy::OrgPolicyNotFound)
+      end
+    end
+
+    context "when space policy doesn't exist" do
+      before do
+        allow_any_instance_of(Conjur::API)
+          .to receive(:resource)
+          .with('cucumber:policy:org_id/space_id')
+          .and_return(nonexistent_resource)
+      end
+
+      it "raises an error" do
+        expect { subject.ensure_exists }.to raise_error(OrgSpacePolicy::SpacePolicyNotFound)
+      end
+    end
+
+    context "when space layer doesn't exist" do
+      before do
+        allow_any_instance_of(Conjur::API)
+          .to receive(:resource)
+          .with('cucumber:layer:org_id/space_id')
+          .and_return(nonexistent_resource)
+      end
+
+      it "raises and error" do
+        expect { subject.ensure_exists }.to raise_error(OrgSpacePolicy::SpaceLayerNotFound)
+      end
+    end
+  end
+end

--- a/spec/models/service_binding_spec.rb
+++ b/spec/models/service_binding_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe ServiceBinding do
+  describe "put" do
+    let(:host) { double("host") }
+
+    before do
+      allow(host).to receive(:exists?).and_return(true)
+      allow(host).to receive(:rotate_api_key)
+      allow_any_instance_of(Conjur::API).to receive(:role).and_return(host)
+    end
+  end
+
   describe "delete" do
     let(:host) { double("host") }
     
@@ -11,20 +21,19 @@ describe ServiceBinding do
     end
     
     it "uses the Conjur API to load policy to delete the host" do
-      if ENV['CONJUR_VERSION'] == 5
+      if ENV['CONJUR_VERSION'] == '5'
+        expected_policy = <<~YAML
+        - !delete
+          record: !host binding_id
+        YAML
         expect_any_instance_of(Conjur::API).
           to receive(:load_policy).
-          with("root",
-      """
-      - !delete
-        record: !host binding_id
-      """,
-          method: :patch
+          with("root", expected_policy, method: :patch
           )
       end
       expect(host).to receive(:rotate_api_key)
 
-      ServiceBinding.new("service_id", "binding_id").delete
+      ServiceBinding.new("service_id", "binding_id", nil, nil).delete
     end
   end
 end

--- a/spec/models/service_binding_spec.rb
+++ b/spec/models/service_binding_spec.rb
@@ -1,17 +1,113 @@
 require 'spec_helper'
 
 describe ServiceBinding do
-  describe "put" do
+  describe "#create" do
     let(:host) { double("host") }
+    let(:policy_load_response) { double("response")}
 
     before do
-      allow(host).to receive(:exists?).and_return(true)
-      allow(host).to receive(:rotate_api_key)
+      # Assume V5 unless otherwise set
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return('5')
+
+      allow(host).to receive(:exists?).and_return(false)
       allow_any_instance_of(Conjur::API).to receive(:role).and_return(host)
+
+      allow_any_instance_of(ConjurClient).to receive(:platform).and_return(nil)
+
+      policy_load_response.stub_chain(:created_roles, :values, :first, :[]).and_return("api_key")
     end
+
+    context "when space context is not present" do
+      it "generates all hosts in the foundation policy" do
+        if ENV['CONJUR_VERSION'] == '5'
+          expected_policy = <<~YAML
+          - !host
+            id: binding_id
+          YAML
+          expect_any_instance_of(Conjur::API).
+            to receive(:load_policy).
+            with("root", expected_policy, method: :post
+            ).
+            and_return(policy_load_response)
+        end
+
+        result = ServiceBinding.new("service_id", "binding_id", nil, nil).create
+        expect(result[:authn_login]).to eq("host/binding_id")
+      end
+
+      context "when the platform is present" do
+        before do
+          allow(ConjurClient).to receive(:platform).and_return("platform")
+        end
+        
+        it "generates policy that includes the platform annotation" do
+          if ENV['CONJUR_VERSION'] == '5'
+            expected_policy = <<~YAML
+            - !host
+              id: binding_id
+              annotations:
+                platform: true
+            YAML
+            expect_any_instance_of(Conjur::API).
+              to receive(:load_policy).
+              with("root", expected_policy, method: :post
+              ).
+              and_return(policy_load_response)
+          end
+  
+          result = ServiceBinding.new("service_id", "binding_id", nil, nil).create
+          expect(result[:authn_login]).to eq("host/binding_id")
+        end
+      end
+    end
+
+    context "when space context is present" do
+      subject { ServiceBinding.new("service_id", "binding_id", "org_guid", "space_guid") }
+
+      it "generates hosts within the org/space hierarchy" do
+        if ENV['CONJUR_VERSION'] == '5'
+          expected_policy = <<~YAML
+          - !host
+            id: binding_id
+
+          - !grant
+            role: !layer
+            member: !host binding_id
+          YAML
+          expect_any_instance_of(Conjur::API).
+            to receive(:load_policy).
+            with("org_guid/space_guid", expected_policy, method: :post
+            ).
+            and_return(policy_load_response)
+        end
+
+        result = subject.create
+        expect(result[:authn_login]).to eq("host/org_guid/space_guid/binding_id")
+      end
+
+      context "when using Conjur V4" do
+        let(:host) { double("host") }
+
+        before do
+           allow(ConjurClient).to receive(:version).and_return(4)
+           
+           allow(host).to receive(:exists?).and_return(false)
+            allow_any_instance_of(Conjur::API).to receive(:role).and_return(host)
+
+          allow_any_instance_of(ServiceBinding).to receive(:create_host_v4).and_return("v4_api_key")
+        end
+
+        it "generates all hosts in the foundation policy" do 
+          result = subject.create
+          expect(result[:authn_login]).to eq("host/binding_id")
+        end
+      end
+    end
+
   end
 
-  describe "delete" do
+  describe "#delete" do
     let(:host) { double("host") }
     
     before do
@@ -20,20 +116,22 @@ describe ServiceBinding do
       allow_any_instance_of(Conjur::API).to receive(:role).and_return(host)
     end
     
-    it "uses the Conjur API to load policy to delete the host" do
-      if ENV['CONJUR_VERSION'] == '5'
-        expected_policy = <<~YAML
-        - !delete
-          record: !host binding_id
-        YAML
-        expect_any_instance_of(Conjur::API).
-          to receive(:load_policy).
-          with("root", expected_policy, method: :patch
-          )
-      end
-      expect(host).to receive(:rotate_api_key)
+    context "when space context is not present" do
+      it "uses the Conjur API to load policy to delete the host" do
+        if ENV['CONJUR_VERSION'] == '5'
+          expected_policy = <<~YAML
+          - !delete
+            record: !host binding_id
+          YAML
+          expect_any_instance_of(Conjur::API).
+            to receive(:load_policy).
+            with("root", expected_policy, method: :patch
+            )
+        end
+        expect(host).to receive(:rotate_api_key)
 
-      ServiceBinding.new("service_id", "binding_id", nil, nil).delete
+        ServiceBinding.new("service_id", "binding_id", nil, nil).delete
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require File.expand_path('../../config/environment', __FILE__)
+
+require 'rspec/rails'


### PR DESCRIPTION
This PR updates the Conjur service broker to include the Organization GUID and Space GUID from PCF into the host identity for the application, and to add the applications to Conjur `!layers` for the org and space. This allows a Conjur operator to permit an application to access resources based on the Space or Org in which it is deployed, rather than only on the application bind id itself.

Connected to #63 

Jenkins: https://jenkins.conjur.net/job/cyberark--conjur-service-broker/job/63-add-host-to-org-space-policy/

## Reviewer Notes

The acceptance criteria for this change are below, with references to the relevant PR changes:
- [ ] Flows are implemented to create host and add to space layer on bind
    > The flow changes to add the host to the space layer are in: https://github.com/cyberark/conjur-service-broker/pull/73/commits/122c41f3a6fdc7ebcbc2c2db546fd8c4c9f3677a

- [ ] Unit (RSpec) tests verify new org/space/app binding functionality
    > See changes in [bind_controller_spec.rb](https://github.com/cyberark/conjur-service-broker/blob/179f66f0fee2f45e5ff9ebaa89ac021ceb0237bb/spec/controllers/bind_controller_spec.rb#L57-L66)

- [ ] Unit (RSpec) tests verify backward compatibility when no org/space context is present 
    > See changes in [bind_controller_spec.rb](https://github.com/cyberark/conjur-service-broker/blob/179f66f0fee2f45e5ff9ebaa89ac021ceb0237bb/spec/controllers/bind_controller_spec.rb#L43-L55)

- [ ] Unit (RSpec) tests verify Conjur V4 functionality is maintained
    > See changes in [bind_controller_spec.rb](https://github.com/cyberark/conjur-service-broker/blob/179f66f0fee2f45e5ff9ebaa89ac021ceb0237bb/spec/controllers/bind_controller_spec.rb#L68-L83)

- [ ] Integration (Cucumber) tests verify new functionality
    > See commit: https://github.com/cyberark/conjur-service-broker/pull/73/commits/c8f1bfce72c71cc6d260753bf8c46e4cfbf37461

- [ ] README is updated with documentation on org / space layer functionality with recommendations for how to leverage the functionality / supported versions
    > See commit: https://github.com/cyberark/conjur-service-broker/pull/73/commits/0b6f86c55ce4486f0763e79109e2900180f00a70

- [ ] Issue created in [docs repo](https://github.com/cyberark/docs-cyberark-conjur-service-broker)  to update tile docs to describe new policy structure and bind behavior
    > https://github.com/cyberark/docs-cyberark-conjur-service-broker/issues/2