### PR TITLE
Generate Org and Space Policy on Provision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- The service broker will now automatically generate the org and space policy when 
+  the service is provisioned into a CF space.
+
 ### Changed
 - Updated dependencies and Ruby version of Docker image
 - The service broker now adds application Hosts to a Conjur Layer for a Space when the

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -83,4 +83,21 @@ class ApplicationController < ActionController::API
     logger.warn("HTTP Basic: Access Denied")
     render json: {}, status: :unauthorized
   end
+
+  def use_context?
+    # Only create the policy for Conjur V5
+    ConjurClient.v5? && org_guid.present? && space_guid.present?
+  end
+
+  def instance_id
+    params[:instance_id]
+  end
+
+  def org_guid
+    params.dig(:context, :organization_guid)
+  end
+
+  def space_guid
+    params.dig(:context, :space_guid)
+  end
 end

--- a/app/controllers/bind_controller.rb
+++ b/app/controllers/bind_controller.rb
@@ -21,24 +21,7 @@ class BindController < ApplicationController
     render json: {}
   end
 
-  def org_guid
-    params.dig(:context, :organization_guid)
-  end
-
-  def space_guid
-    params.dig(:context, :space_guid)
-  end
-
-  def instance_id
-    params[:instance_id]
-  end
-
   def binding_id
     params[:binding_id]
-  end
-
-  def use_context?
-    # Only create the policy for Conjur V5
-    ConjurClient.v5? && org_guid.present? && space_guid.present?
   end
 end

--- a/app/controllers/provision_controller.rb
+++ b/app/controllers/provision_controller.rb
@@ -1,8 +1,19 @@
+require 'typed_env'
+
 class ProvisionController < ApplicationController
   def put
     Validator.validate('provision', params.to_unsafe_h)
 
-    render :json => {}
+    if use_context?
+      with_conjur_exceptions do
+        ServiceInstancePolicy.create(instance_id, org_guid, space_guid)
+        OrgSpacePolicy.create(org_guid, space_guid)
+      end
+
+      render json: {}, status: :created
+    else
+      render json: {}
+    end
   end
 
   def patch
@@ -14,6 +25,27 @@ class ProvisionController < ApplicationController
   def delete
     Validator.validate('deprovision', params.to_unsafe_h)
 
+    with_conjur_exceptions do
+      instance = ServiceInstance.new(instance_id)
+
+      if instance.exists?
+        delete_org_space_policy(instance) unless preserve_policy?
+        ServiceInstancePolicy.delete(instance_id)
+      end
+    end
+
     render json: {}
+  end
+
+  protected
+
+  def preserve_policy?
+    TypedEnv.boolean('CONJUR_PRESERVE_POLICY')
+  end
+
+  private
+
+  def delete_org_space_policy(instance)
+    OrgSpacePolicy.delete(instance.organization_guid, instance.space_guid)
   end
 end

--- a/app/models/conjur_api_model.rb
+++ b/app/models/conjur_api_model.rb
@@ -1,0 +1,14 @@
+module ConjurApiModel
+
+  def load_policy(policy, method: Conjur::API::POLICY_METHOD_POST)
+    conjur_api.load_policy(ConjurClient.policy, policy, method: method)
+  end
+
+  def policy_base
+    ConjurClient.policy != 'root' ? ConjurClient.policy + '/' : ''
+  end
+
+  def conjur_api
+    ConjurClient.api
+  end
+end

--- a/app/models/schemas/provision.json
+++ b/app/models/schemas/provision.json
@@ -45,8 +45,6 @@
   },
   "required": [
     "service_id",
-    "plan_id",
-    "organization_guid",
-    "space_guid"
+    "plan_id"
   ]
 }

--- a/app/models/service_binding.rb
+++ b/app/models/service_binding.rb
@@ -1,6 +1,7 @@
 require 'conjur_client'
 
 class ServiceBinding
+  include ConjurApiModel
 
   class RoleAlreadyCreated < RuntimeError
   end
@@ -136,16 +137,8 @@ class ServiceBinding
     "#{ConjurClient.account}:host:#{host_id}"
   end
 
-  def conjur_api
-    ConjurClient.api
-  end
-
   def use_space?
     ConjurClient.v5? && @org_guid.present? && @space_guid.present?
-  end
-
-  def policy_base
-    ConjurClient.policy != 'root' ? ConjurClient.policy + '/' : ''
   end
 
   def space_policy

--- a/app/models/service_instance.rb
+++ b/app/models/service_instance.rb
@@ -1,0 +1,35 @@
+require 'forwardable'
+
+class ServiceInstance
+  include ConjurApiModel
+  extend Forwardable
+
+  def_delegators :resource, :exists?
+
+  class InstanceNotFound < RuntimeError
+  end
+
+  def initialize(instance_id)
+    @instance_id = instance_id
+  end
+
+  def organization_guid
+    raise InstanceNotFound unless resource.exists?
+
+    resource&.annotations['organization-guid']
+  end
+
+  def space_guid
+    raise InstanceNotFound unless resource.exists?
+
+    resource&.annotations['space-guid']
+  end
+
+  def resource
+    @resource ||= conjur_api.resource(resource_id)
+  end
+
+  def resource_id
+    "#{ConjurClient.account}:cf-service-instance:#{policy_base}#{@instance_id}"
+  end
+end

--- a/app/models/service_instance_policy.rb
+++ b/app/models/service_instance_policy.rb
@@ -1,0 +1,53 @@
+require 'conjur_client'
+
+class ServiceInstancePolicy
+  include ConjurApiModel
+
+  class << self
+    def create(instance_id, org_id, space_id)
+      ServiceInstancePolicy.new(instance_id).create(org_id, space_id)
+    end
+
+    def delete(instance_id)
+      ServiceInstancePolicy.new(instance_id).delete
+    end
+  end
+
+  def initialize(instance_id)
+    @instance_id = instance_id
+  end
+
+  def create(org_id, space_id)
+    load_policy(template_create_instance(org_id, space_id))
+  end
+
+  def delete
+    load_policy(template_delete_instance, 
+      method: Conjur::API::POLICY_METHOD_PATCH)
+  end
+
+  private
+  
+  def template_create_instance(org_id, space_id)
+    <<~YAML
+    ---
+    - !resource
+      id: #{@instance_id}
+      kind: cf-service-instance
+      annotations:
+        organization-guid: #{org_id}
+        space-guid: #{space_id}
+    YAML
+  end
+
+  def template_delete_instance
+    <<~YAML
+    ---
+    - !delete
+      record:
+        !resource
+        id: #{@instance_id}
+        kind: cf-service-instance
+    YAML
+  end
+end

--- a/ci/integration/policy/app.yml
+++ b/ci/integration/policy/app.yml
@@ -3,32 +3,17 @@
 - !policy
   id: app
   body:
-  - &variables
     - !variable
-      id: database/username
+      id: secrets/org
       annotations:
-        description: Application database username
+        description: Org-wide secret
+
     - !variable
-      id: database/password
+      id: secrets/space
       annotations:
-        description: Application database password
+        description: Space-wide secret
 
-  - !group secrets-users
-  - !group secrets-managers
-
-  # secrets-managers has role secrets-users
-  - !grant
-    role: !group secrets-users
-    member: !group secrets-managers
-
-  # secrets-users can read and execute
-  - !permit
-    resource: *variables
-    privileges: [ read, execute ]
-    role: !group secrets-users
-
-  # secrets-managers can update (and read and execute, via role grant)
-  - !permit
-    resource: *variables
-    privileges: [ update ]
-    role: !group secrets-managers
+    - !variable
+      id: secrets/app
+      annotations:
+        description: App-specific secret

--- a/ci/integration/test-app/secrets.yml
+++ b/ci/integration/test-app/secrets.yml
@@ -1,2 +1,3 @@
-DB_USERNAME: !var app/database/username
-DB_PASSWORD: !var app/database/password
+ORG_SECRET: !var app/secrets/org
+SPACE_SECRET: !var app/secrets/space
+APP_SECRET: !var app/secrets/app

--- a/ci/integration/test-app/test_app.rb
+++ b/ci/integration/test-app/test_app.rb
@@ -8,8 +8,9 @@ class TestApp < Sinatra::Application
   
   get '/' do
     "
-      <p>Database Username: #{ENV['DB_USERNAME']}</p>
-      <p>Database Password: #{ENV['DB_PASSWORD']}</p>
+      <p>Org Secret: #{ENV['ORG_SECRET']}</p>
+      <p>Space Secret: #{ENV['SPACE_SECRET']}</p>
+      <p>App Secret: #{ENV['APP_SECRET']}</p>
     "
   end
 

--- a/features/integration.feature
+++ b/features/integration.feature
@@ -1,16 +1,68 @@
+# These tests only need to run once, because we use an external
+# Conjur server, so we'll tag them to run with the V5 tests (the
+# external server is Conjur V5 Enterprise)
+@conjur-version-5
 @integration
-Feature: Integration Tests
+@service-broker
+Feature: Integration Tests for PCF 2.4
 
-  Scenario: Service broker functions correctly with PCF 2.4
-  
-    Given I login to PCF and target my organization and space
-    And I load a secret into Conjur
-    And I install the service broker
-    And I create a service instance for Conjur
-    And I load policy to define my org and space
+  Scenario: Service broker functions correctly with PCF 2.4 
+    When I create a service instance for Conjur
+    Then the instance resource exists
+    And the policy for the org and space exists
+
+    When I load a secret into Conjur
+    And I privilege the org layer to access a secret in Conjur
+    And I privilege the space layer to access a secret in Conjur
+    
+    And I push the sample app to PCF
+    And I privilege the app host to access a secret in Conjur
+    And I start the app
+    Then I can retrieve the secret values from the app
+
+    When I remove the service instance
+    Then the policy for the org and space doesn't exist
+    And the instance resource doesn't exist
+
+  @preserve-policy
+  Scenario: Service broker functions preserves the policy if configured
+    When I create a service instance for Conjur
+    Then the instance resource exists
+    And the policy for the org and space exists
+
+    When I remove the service instance
+    Then the policy for the org and space exists
+    And the instance resource doesn't exist
+
+  @preserve-policy
+  Scenario: Redeploying service broker
+    When I create a service instance for Conjur
+    Then the instance resource exists
+    And the policy for the org and space exists
+
+    When I load a secret into Conjur
+    And I privilege the org layer to access a secret in Conjur
+    And I privilege the space layer to access a secret in Conjur
+    
+    And I push the sample app to PCF
+    And I privilege the app host to access a secret in Conjur
+    And I start the app
+    Then I can retrieve the secret values from the app
+
+    When I remove the service instance
+    Then the policy for the org and space exists
+    And the instance resource doesn't exist
+
+    # Redeploy and run app, maintaining existing policy
+    When I create a service instance for Conjur
 
     When I push the sample app to PCF
-    And I privilege the app to access the secret in Conjur
+    # The app host will have a new binding ID, so we need to grant
+    # permissions for the app specific secret again, but not for the
+    # org/space secrets:
+    And I privilege the app host to access a secret in Conjur
     And I start the app
+    Then I can retrieve the secret values from the app
 
-    Then I can retrieve the secret value from the app
+    When I remove the service instance
+    Then the policy for the org and space exists

--- a/features/provision.feature
+++ b/features/provision.feature
@@ -45,6 +45,27 @@ Feature: Provisioning
       }
       """
 
+  @conjur-version-5
+  Scenario: Provision resource
+    When I PUT "/v2/service_instances/9b292a9c-af66-4797-8d98-b30801f32ax7" with body:
+    """
+    {
+      "context": {
+        "organization_guid": "e027f3f6-80fe-4d22-9374-da23a035ba0a",
+        "space_guid": "8c56f85c-c16e-4158-be79-5dac74f970db"
+      },
+      "service_id": "c024e536-6dc4-45c6-8a53-127e7f8275ab",
+      "plan_id": "3a116ac2-fc8b-496f-a715-e9a1b205d05c.community",
+      "organization_guid": "e027f3f6-80fe-4d22-9374-da23a035ba0a",
+      "space_guid": "8c56f85c-c16e-4158-be79-5dac74f970db",
+      "parameters": {
+      }
+    }
+    """
+    Then the HTTP response status code is "201"
+    And the JSON should be {}
+
+  @conjur-version-4
   Scenario: Provision resource
     When I PUT "/v2/service_instances/9b292a9c-af66-4797-8d98-b30801f32ax7" with body:
     """

--- a/features/step_definitions/integration_steps.rb
+++ b/features/step_definitions/integration_steps.rb
@@ -1,24 +1,16 @@
 Given(/^I login to PCF and target my organization and space$/) do
   login_to_pcf
-
-  cf_target('ci', 'conjur-service-broker')
+  cf_target(cf_ci_org, cf_ci_space)
 end
 
 Given(/^I load a secret into Conjur$/) do
-  store_secret_in_remote_conjur("#{ENV['PCF_CONJUR_ACCOUNT']}:variable:app/database/username", ci_secret_user)
-  store_secret_in_remote_conjur("#{ENV['PCF_CONJUR_ACCOUNT']}:variable:app/database/password", ci_secret_pass)
-end
-
-Given(/^I install the service broker$/) do
-  install_service_broker
+  store_secret_in_remote_conjur("#{ENV['PCF_CONJUR_ACCOUNT']}:variable:app/secrets/org", ci_secret_org)
+  store_secret_in_remote_conjur("#{ENV['PCF_CONJUR_ACCOUNT']}:variable:app/secrets/space", ci_secret_space)
+  store_secret_in_remote_conjur("#{ENV['PCF_CONJUR_ACCOUNT']}:variable:app/secrets/app", ci_secret_app)
 end
 
 Given(/^I create a service instance for Conjur$/) do
   `cf create-service cyberark-conjur community conjur`
-end
-
-Given(/^I load policy to define my org and space$/) do
-  load_space_policy_in_remote_conjur('ci', 'conjur-service-broker')
 end
 
 When(/^I push the sample app to PCF$/) do
@@ -28,18 +20,47 @@ When(/^I push the sample app to PCF$/) do
   end
 end
 
-When(/^I privilege the app to access the secret in Conjur$/) do
-  entitle_host_in_remote_conjur(app_bind_id)
-end
-
 When(/^I start the app$/) do
   Dir.chdir(integration_test_app_dir) do
     `cf start hello-world`
   end
 end
 
-Then(/^I can retrieve the secret value from the app$/) do
+Then(/^I can retrieve the secret values from the app$/) do
   page_content = ci_app_content
-  expect(page_content).to match(/Database Username: #{ci_secret_user}/)
-  expect(page_content).to match(/Database Password: #{ci_secret_pass}/)
+  expect(page_content).to match(/Org Secret: #{ci_secret_org}/)
+  expect(page_content).to match(/Space Secret: #{ci_secret_space}/)
+  expect(page_content).to match(/App Secret: #{ci_secret_app}/)
+end
+
+Then(/^the policy for the org and space( doesn't)? exist(?:s)?$/) do |negative|
+  expect(remote_conjur_resource_exists?(org_policy_id)).to eq(negative.blank?)
+  expect(remote_conjur_resource_exists?(space_policy_id)).to eq(negative.blank?)
+end
+
+Then(/^the instance resource( doesn't)? exist(?:s)?$/) do |negative|
+  expect(remote_conjur_resource_exists?(instance_resource_id)).to eq(negative.blank?)
+end
+
+When(/^I privilege the org layer to access a secret in Conjur$/) do
+  role = "!layer pcf/ci/#{org_guid(cf_ci_org)}"
+  secret = "!variable app/secrets/org"
+  privilege_in_remote_conjur(role, secret)
+end
+
+When(/^I privilege the space layer to access a secret in Conjur$/) do
+  role = "!layer pcf/ci/#{org_guid(cf_ci_org)}/#{space_guid(cf_ci_org, cf_ci_space)}"
+  secret = "!variable app/secrets/space"
+  privilege_in_remote_conjur(role, secret)
+end
+
+When(/^I privilege the app host to access a secret in Conjur$/) do
+  role = "!host pcf/#{app_bind_id}"
+  secret = "!variable app/secrets/app"
+  privilege_in_remote_conjur(role, secret)
+end
+
+When(/^I remove the service instance$/) do
+  `cf unbind-service hello-world conjur`
+  `cf delete-service conjur -f`
 end

--- a/features/support/conjur_helper.rb
+++ b/features/support/conjur_helper.rb
@@ -24,6 +24,12 @@ module ConjurHelper
     end
   end
 
+  def remote_conjur_resource_exists?(id)
+    remote_conjur do |api|
+      api.resource(id).exists?
+    end
+  end
+
   def store_secret_in_remote_conjur(var_id, value)
     remote_conjur do |api|
       api.resource(var_id).add_value(value)

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,20 @@
 Before("@conjur-version-5") do
   skip_this_scenario unless ENV['CONJUR_VERSION'] == "5"
 end
+
+Before("@conjur-version-4") do
+  skip_this_scenario unless ENV['CONJUR_VERSION'] == "4"
+end
+
+Before("@service-broker") do |scenario|
+  login_to_pcf
+  cf_target(cf_ci_org, cf_ci_space)
+
+  preserve = scenario.source_tag_names.include?('@preserve-policy')
+  install_service_broker(preserve)
+end
+
+After("@service-broker") do
+  cf_target(cf_ci_org, cf_ci_space)
+  cleanup_service_broker
+end

--- a/lib/typed_env.rb
+++ b/lib/typed_env.rb
@@ -1,0 +1,9 @@
+class TypedEnv
+  class << self
+    TRUTHY_VALUES = %w(t true yes y 1).freeze
+
+    def boolean(name)
+      TRUTHY_VALUES.include?(ENV[name].to_s.downcase)
+    end
+  end
+end

--- a/spec/controllers/deprovision_controller_spec.rb
+++ b/spec/controllers/deprovision_controller_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-class DeprovisionControllerTest < ActionDispatch::IntegrationTest
-  # spec "the truth" do
-  #   assert true
-  # end
-end

--- a/spec/controllers/provision_controller_spec.rb
+++ b/spec/controllers/provision_controller_spec.rb
@@ -1,7 +1,174 @@
 require 'spec_helper'
 
-class ProvisionControllerTest < ActionDispatch::IntegrationTest
-  # spec "the truth" do
-  #   assert true
-  # end
+
+RSpec.describe ProvisionController, type: :request do
+  let(:username) { ENV['SECURITY_USER_NAME'] }
+  let(:password) { ENV['SECURITY_USER_PASSWORD'] }
+
+  let(:headers) do
+    {
+      'X-Broker-API-Version' => '2.13',
+      'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(username, password)
+    }
+  end
+
+  describe 'PUT' do
+    let(:legacy_params) do
+      {
+        service_id: 'c024e536-6dc4-45c6-8a53-127e7f8275ab',
+        plan_id: '3a116ac2-fc8b-496f-a715-e9a1b205d05c.community',
+        context: {
+          platform: 'cloudfoundry'
+        },
+        organization_guid: 'test_org',
+        space_guid: 'test_space'
+      }
+    end
+  
+    let(:params) do 
+      legacy_params.merge({
+        context: {
+          organization_guid: 'test_org',
+          space_guid: 'test_space'
+        }
+      })
+    end
+
+    before do
+      # Assume V5 unless otherwise set
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return('5')
+    end
+
+    context 'when context is present' do
+      it 'creates the org and space policy' do
+        expect_any_instance_of(ServiceInstancePolicy).to receive(:create)
+        expect_any_instance_of(OrgSpacePolicy).to receive(:create)
+
+        put('/v2/service_instances/test_instance', params: params, headers: headers)
+
+        expect(response).to have_http_status(:created)
+        expect(response.content_type).to eq("application/json")
+        expect(response.body).to eq("{}")
+      end
+
+      context 'when using Conjur V4' do
+        before do
+          allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return('4')
+        end
+
+        it 'does not create the org and space policy' do
+          expect_any_instance_of(ServiceInstancePolicy).not_to receive(:create)
+          expect_any_instance_of(OrgSpacePolicy).not_to receive(:create)
+          put('/v2/service_instances/test_instance', params: params, headers: headers)
+          expect(response.content_type).to eq("application/json")
+          expect(response).to have_http_status(:ok)
+          expect(response.body).to eq("{}")
+        end
+      end
+    end
+
+    context 'when context is not present' do
+      it 'does not create the org and space policy' do
+        expect_any_instance_of(ServiceInstancePolicy).not_to receive(:create)
+        expect_any_instance_of(OrgSpacePolicy).not_to receive(:create)
+
+        put('/v2/service_instances/test_instance', params: legacy_params, headers: headers)
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq("{}")
+      end
+    end
+  end
+
+  describe 'DELETE' do
+    let(:params) do 
+      {
+        service_id: 'c024e536-6dc4-45c6-8a53-127e7f8275ab',
+        plan_id: '3a116ac2-fc8b-496f-a715-e9a1b205d05c.community'
+      }
+    end
+
+    let(:delete_path) { '/v2/service_instances/test_instance'}
+
+    before do
+      # Assume V5 unless otherwise set
+      allow(ENV).to receive(:[]).and_call_original
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return('5')
+
+      allow_any_instance_of(ServiceInstance).to receive(:exists?).and_return(true)
+      allow_any_instance_of(ServiceInstance).to receive(:organization_guid).and_return('org_id')
+      allow_any_instance_of(ServiceInstance).to receive(:space_guid).and_return('space_id')
+
+      allow_any_instance_of(OrgSpacePolicy).to receive(:delete)
+      allow_any_instance_of(ServiceInstancePolicy).to receive(:delete)
+    end
+
+    it "does delete service instance" do
+      expect_any_instance_of(ServiceInstancePolicy).to receive(:delete)
+      delete(delete_path, params: params, headers: headers)
+    end
+
+    it 'deletes the org and space policy' do
+      expect_any_instance_of(OrgSpacePolicy).to receive(:delete)
+      delete(delete_path, params: params, headers: headers)
+    end
+
+    it 'returns with a 200 OK response' do
+      delete(delete_path, params: params, headers: headers)
+
+      expect(response.content_type).to eq("application/json")
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq("{}")
+    end
+
+    context 'when deprovisioning an instance that doesn\'t exist' do
+      before do
+        allow_any_instance_of(ServiceInstance).to receive(:exists?).and_return(false)
+      end
+
+      it "does not delete service instance" do
+        expect_any_instance_of(ServiceInstancePolicy).not_to receive(:delete)
+        delete(delete_path, params: params, headers: headers)
+      end
+
+      it "does not delete org and space policy" do
+        expect_any_instance_of(OrgSpacePolicy).not_to receive(:delete)
+        delete(delete_path, params: params, headers: headers)
+      end
+
+      it 'returns with a 200 OK response' do
+        delete(delete_path, params: params, headers: headers)
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq("{}")
+      end
+    end
+
+    context "when CONJUR_PRESERVE_POLICY is enabled" do
+      before do
+        allow(ENV).to receive(:[]).with('CONJUR_PRESERVE_POLICY').and_return('true')
+      end    
+
+      it "does delete service instance" do
+        expect_any_instance_of(ServiceInstancePolicy).to receive(:delete)
+        delete(delete_path, params: params, headers: headers)
+      end
+
+      it "does not delete org and space policy" do
+        expect_any_instance_of(OrgSpacePolicy).not_to receive(:delete)
+        delete(delete_path, params: params, headers: headers)
+      end
+
+      it 'returns with a 200 OK response' do
+        delete(delete_path, params: params, headers: headers)
+
+        expect(response.content_type).to eq("application/json")
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to eq("{}")
+      end
+    end
+  end
 end

--- a/spec/controllers/unbind_controller_spec.rb
+++ b/spec/controllers/unbind_controller_spec.rb
@@ -1,7 +1,0 @@
-require 'spec_helper'
-
-class UnbindControllerTest < ActionDispatch::IntegrationTest
-  # spec "the truth" do
-  #   assert true
-  # end
-end

--- a/spec/models/org_space_policy_spec.rb
+++ b/spec/models/org_space_policy_spec.rb
@@ -2,15 +2,139 @@ require 'spec_helper'
 
 describe OrgSpacePolicy do
 
-  describe "#ensure_exists" do
-    let(:existent_resource) { double("existent") }
-    let(:nonexistent_resource) { double("non-existent") }
+  let(:org_guid) { "my_org" }
+  let(:space_guid) { "my_space" }
+  let(:policy_name) { 'cf' }
 
-    subject { OrgSpacePolicy.new("org_id", "space_id") }
-    
+  subject { OrgSpacePolicy.new(org_guid, space_guid) }   
+
+  before do
+    allow(ConjurClient).to receive(:policy).and_return(policy_name)    
+    allow(ConjurClient).to receive(:login_host_id).and_return('service-broker')  
+
+    allow(ENV).to receive(:[]).and_call_original
+  end
+
+  let(:create_policy_body) do
+    <<~YAML
+      ---
+      - !policy
+        id: #{org_guid}
+        body:
+          - !layer
+
+          - !policy
+            id: #{space_guid}
+            body:
+              - !layer
+
+          - !grant
+            role: !layer
+            member: !layer #{space_guid}
+      YAML
+  end
+
+  describe "#create" do
+    it "loads Conjur policy to create the org and space policy" do
+      expect_any_instance_of(Conjur::API).
+        to receive(:load_policy).
+        with(policy_name, create_policy_body, method: :post)
+
+      subject.create
+    end
+  end
+
+  describe "#delete" do
+    let(:org_policy_resource) do
+      double('org_policy_resource', 
+       id: double("org_policy_id", identifier: "#{policy_name}/#{org_guid}")
+       ) 
+    end
+
+    let(:space_policy_resource) do
+      double('space_policy_resource', 
+        id: double("space_policy_id", identifier: "#{policy_name}/#{org_guid}/#{space_guid}")
+        ) 
+    end
+
+    let(:org_id_search_results) do
+      [
+        org_policy_resource
+      ]
+    end
+
+    let(:api) { double('api') }
+
+    let(:delete_org_policy_body) do
+      <<~YAML
+      ---
+      - !delete
+        record: !policy #{org_guid}
+      YAML
+    end
+
+    let(:delete_space_policy_body) do
+      <<~YAML
+      ---
+      - !delete
+        record: !policy #{org_guid}/#{space_guid}
+      YAML
+    end
+
+    before do 
+      allow(ConjurClient).to receive(:api).and_return(api)
+
+      allow(api).to receive(:resources)
+        .with(kind: 'policy', account: ConjurClient.account, search: "#{policy_name}/#{org_guid}")
+        .and_return(org_id_search_results)
+    end
+
+    it "loads Conjur policy to remove the org and space policy" do
+      expect(api).
+        to receive(:load_policy).
+        with(policy_name, delete_space_policy_body, method: :patch)
+
+      expect(api).
+        to receive(:load_policy).
+        with(policy_name, delete_org_policy_body, method: :patch)
+
+      subject.delete
+    end
+
+    context "when an org policy includes multiple spaces" do
+
+      let(:another_space_policy_resource) do
+        double('space_policy_resource', 
+         id: double("space_policy_id", identifier: "#{policy_name}/#{org_guid}/another_space")
+         ) 
+      end
+
+      let(:org_id_search_results) do
+        [
+          org_policy_resource,
+          another_space_policy_resource
+        ]
+      end
+          
+      it "loads Conjur policy to remove the space policy but not the org" do
+        expect(api).
+          to receive(:load_policy).
+          with(policy_name, delete_space_policy_body, method: :patch)
+
+        expect(api).
+          not_to receive(:load_policy).
+          with(policy_name, delete_org_policy_body, method: :patch)
+
+        subject.delete
+      end
+    end
+  end
+
+  describe "#ensure_exists" do
+    let(:existent_resource) { double("existent", exists?: true) }
+    let(:nonexistent_resource) { double("non-existent", exists?: false) }
+  
     before do
-      allow(existent_resource).to receive(:exists?).and_return(true)
-      allow(nonexistent_resource).to receive(:exists?).and_return(false)
 
       # By default, assume all resources exist
       allow_any_instance_of(Conjur::API)
@@ -20,8 +144,8 @@ describe OrgSpacePolicy do
     end
 
     context "when resources already exist" do
-      it "does nothing" do
-        subject.ensure_exists
+      it "does not raise an error" do
+        expect { subject.ensure_exists}.not_to raise_error
       end
     end
 
@@ -29,7 +153,7 @@ describe OrgSpacePolicy do
       before do
         allow_any_instance_of(Conjur::API)
           .to receive(:resource)
-          .with('cucumber:policy:org_id').
+          .with("cucumber:policy:#{policy_name}/#{org_guid}").
           and_return(nonexistent_resource)
       end
 
@@ -42,7 +166,7 @@ describe OrgSpacePolicy do
       before do
         allow_any_instance_of(Conjur::API)
           .to receive(:resource)
-          .with('cucumber:policy:org_id/space_id')
+          .with("cucumber:policy:#{policy_name}/#{org_guid}/#{space_guid}")
           .and_return(nonexistent_resource)
       end
 
@@ -55,7 +179,7 @@ describe OrgSpacePolicy do
       before do
         allow_any_instance_of(Conjur::API)
           .to receive(:resource)
-          .with('cucumber:layer:org_id/space_id')
+          .with("cucumber:layer:#{policy_name}/#{org_guid}/#{space_guid}")
           .and_return(nonexistent_resource)
       end
 

--- a/spec/models/service_instance_policy_spec.rb
+++ b/spec/models/service_instance_policy_spec.rb
@@ -1,0 +1,74 @@
+require 'spec_helper'
+
+describe ServiceInstancePolicy do
+
+  let(:instance_id) { "my_instance" }
+  let(:org_guid) { "my_org" }
+  let(:space_guid) { "my_space" }
+  let(:policy_name) { 'cf' }
+
+  subject { ServiceInstancePolicy.new(instance_id) }   
+
+  before do
+    allow(ConjurClient).to receive(:policy).and_return(policy_name)    
+    allow(ConjurClient).to receive(:login_host_id).and_return('service-broker')  
+
+    allow(ENV).to receive(:[]).and_call_original
+  end
+
+  let(:create_policy_body) do
+    <<~YAML
+      ---
+      - !resource
+        id: #{instance_id}
+        kind: cf-service-instance
+        annotations:
+          organization-guid: #{org_guid}
+          space-guid: #{space_guid}
+      YAML
+  end
+
+  describe "#create" do
+    it "loads Conjur policy to create the service instance resource" do
+      expect_any_instance_of(Conjur::API).
+        to receive(:load_policy).
+        with(policy_name, create_policy_body, method: :post)
+
+      subject.create(org_guid, space_guid)
+    end
+  end
+
+  describe "#delete" do
+
+    let(:org_id_search_results) do
+      [
+        org_policy_resource
+      ]
+    end
+
+    let(:api) { double('api') }
+
+    let(:delete_instance_policy_body) do
+      <<~YAML
+      ---
+      - !delete
+        record:
+          !resource
+          id: #{instance_id}
+          kind: cf-service-instance
+      YAML
+    end
+
+    before do 
+      allow(ConjurClient).to receive(:api).and_return(api)
+    end
+
+    it "loads Conjur policy to remove the service instance" do
+      expect(api).
+        to receive(:load_policy).
+        with(policy_name, delete_instance_policy_body, method: :patch)
+
+      subject.delete
+    end
+  end
+end

--- a/spec/models/service_instance_spec.rb
+++ b/spec/models/service_instance_spec.rb
@@ -1,0 +1,51 @@
+RSpec.describe ServiceInstance do
+
+  let(:policy_name) { 'cf' }
+  let(:instance_id) {'my_instance'}
+
+  let(:organization_guid) { 'my_org' }
+  let(:space_guid) { 'my_space' }
+
+  let(:annotations) { {
+    'organization-guid' => organization_guid,
+    'space-guid' => space_guid
+  }}
+
+  let(:resource) { double('resource', exists?: true, annotations: annotations) }
+
+  before do
+    allow(ConjurClient).to receive(:policy).and_return(policy_name)    
+
+    allow_any_instance_of(Conjur::API).to receive(:resource)
+      .with("#{ConjurClient.account}:cf-service-instance:cf/#{instance_id}")
+      .and_return(resource)
+  end
+
+  subject { ServiceInstance.new(instance_id) }
+
+  describe "#organization_guid" do
+    it 'returns the guid annotation value' do
+      expect(subject.organization_guid).to equal(organization_guid)
+    end
+    context "when the resource doesn't exist" do
+      before { allow(resource).to receive(:exists?).and_return(false) }
+
+      it "raises an error" do
+        expect {subject.organization_guid}.to raise_error(ServiceInstance::InstanceNotFound)
+      end
+    end
+  end
+
+  describe "#space_guid" do
+    it 'returns the guid annotation value' do
+      expect(subject.space_guid).to equal(space_guid)
+    end
+    context "when the resource doesn't exist" do
+      before { allow(resource).to receive(:exists?).and_return(false) }
+
+      it "raises an error" do
+        expect {subject.space_guid}.to raise_error(ServiceInstance::InstanceNotFound)
+      end
+    end
+  end  
+end


### PR DESCRIPTION
This PR updates the service broker to automatically generate the policy for a CF org and space when the service is provisioned inside of a space.

Additionally, when the service is de-provisioned, it will clean up the policy for that space. This behavior may be disabled by setting the environment variable `CONJUR_PRESERVE_POLICY` to `true`.

Connected to #70 

Jenkins Build:
https://jenkins.conjur.net/job/cyberark--conjur-service-broker/job/70-provision-space-policy/

AC:
- [ ] Service broker is updated to generate policy for the organization and space in the `ProvisionController`
- [ ] Unit (RSpec) tests verify new functionality
- [ ] Unit (RSpec) tests verify backward compatibility for older PCF
- [ ] Integration (Cucumber) tests verify new functionality
- [ ] Integration (Cucumber) tests verify preserve policy behavior
- [ ] Integration (Cucumber) tests verify that apps may be entitled either by org, space, or app identity

- [ ] Issue created in [docs repo](https://github.com/cyberark/docs-cyberark-conjur-service-broker) to update docs to describe provision behavior
    > https://github.com/cyberark/docs-cyberark-conjur-service-broker/issues/4

- [ ] Issue created to add `CONJUR_PRESERVE_POLICY` parameter to tile
    > https://github.com/conjurinc/cloudfoundry-conjur-tile/issues/14