### PR TITLE
Bump rack and sinatra versions in test app

### DIFF
--- a/ci/integration/test-app/Gemfile
+++ b/ci/integration/test-app/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'sinatra'
+gem 'sinatra', ">= 2.0.2"
+gem 'rack', ">= 2.0.6"
 gem 'conjur-api'
 gem 'conjur-cli'

--- a/ci/integration/test-app/Gemfile.lock
+++ b/ci/integration/test-app/Gemfile.lock
@@ -32,23 +32,23 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
     minitest (5.10.3)
-    mustermann (1.0.1)
+    mustermann (1.0.3)
     netrc (0.11.0)
-    rack (2.0.3)
-    rack-protection (2.0.0)
+    rack (2.0.6)
+    rack-protection (2.0.5)
       rack
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    sinatra (2.0.0)
+    sinatra (2.0.5)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.0)
+      rack-protection (= 2.0.5)
       tilt (~> 2.0)
     table_print (1.5.6)
     thread_safe (0.3.6)
-    tilt (2.0.8)
+    tilt (2.0.9)
     tzinfo (1.2.4)
       thread_safe (~> 0.1)
     unf (0.1.4)
@@ -62,7 +62,8 @@ PLATFORMS
 DEPENDENCIES
   conjur-api
   conjur-cli
-  sinatra
+  rack (>= 2.0.6)
+  sinatra (>= 2.0.2)
 
 BUNDLED WITH
-   1.16.0
+   1.17.1


### PR DESCRIPTION
Connected to #74 

Minor update to bump the versions of rack and sinatra in the CI test app to address vulnerability warnings. These are not critical errors since they are in a test app used for CI tests only, but I've updated them in any case.

**Note**: I also added `unset CF_API_ENDPOINT` to the method that runs the v4 test suite, bc it was re-running the integration test which (as I understand it) is running against an already deployed v5 Conjur instance. Also, it could be clearer in the docs (maybe in the integration test section of CONTRIBUTING.md?) what exactly the integration tests are running as part of the build - I don't know if it's running against Conjur v5 EE or Conjur OSS.