### PR TITLE
Update health check to treat an empty string for follower as not configured

### DIFF
--- a/bin/health-check.rb
+++ b/bin/health-check.rb
@@ -62,7 +62,7 @@ end
 # If a follower URL is provided, test it using the Conjur API.
 follower_url = ENV['CONJUR_FOLLOWER_URL']
 
-unless follower_url.nil?
+if follower_url.present?
   begin
     follower_api = ConjurClient.new.api(follower_url)
     

--- a/features/health-check.feature
+++ b/features/health-check.feature
@@ -20,6 +20,11 @@ Feature: Health Check
     Then the output includes 'Host identity not privileged to read itself.'
     And the exit status should be 1
 
+Scenario: Empty Conjur Follower URL
+    When I run the health check script with env CONJUR_FOLLOWER_URL=
+    Then the output includes 'Successfully validated Conjur credentials'
+    And the exit status should be 0
+
   Scenario: Invalid Conjur Follower URL
     When I run the health check script with env CONJUR_FOLLOWER_URL=not-a-follower-url
     Then the output includes 'There is an issue with your CONJUR_FOLLOWER_URL value.'


### PR DESCRIPTION
Connected to #88 

This PR updates the follower url check from `unless ... nil?` to `if present?` to account for a blank (or whitespace string) value.