### PR TITLE
Update README to document Space Host Identity Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,13 @@ The Conjur Buildpack uses [Summon](https://cyberark.github.io/summon/) to load s
 
 For instructions on installing and using the Conjur Buildpack, please [see the Conjur Buildpack documentation](https://github.com/cyberark/cloudfoundry-conjur-buildpack).
 
-## <a name="usage"> Service Broker Usage
+## <a name="usage"> Using the Conjur Service Broker
 
-### Creating a Conjur Service Instance
+- [Creating a Service Instance](#prepare-space)
+- [Connecting an Application to Conjur](#connect-app)
+- [Rotating App Host Credentials](#rotate-credentials)
+
+### <a name="prepare-space"> Creating a Conjur Service Instance
 
 1. **Confirm Conjur Service is in the Marketplace**
 
@@ -248,7 +252,7 @@ For instructions on installing and using the Conjur Buildpack, please [see the C
           member: !layer 8bf39f4a-ebde-437b-9c38-3d234b80631a
     ```
 
-### Using Conjur with a Cloud Foundry Application
+### <a name="connect-app"> Using Conjur with a Cloud Foundry Application
 
 1. **Create a `secrets.yml` File**
 
@@ -378,7 +382,7 @@ For instructions on installing and using the Conjur Buildpack, please [see the C
 The secrets are now available to be used by the application, but are not visible
 when you run `cf env my-app` or if you `cf ssh my-app` and run `printenv`.
 
-### Rotating Host API Keys
+### <a name="rotate-credentials"> Rotating Host API Keys
 
 When the API key for a PCF application host is rotated, the application needs to be re-bound
 to the Conjur service instance to receive the new credentials, and then re-staged to fetch secret

--- a/README.md
+++ b/README.md
@@ -4,7 +4,13 @@ You will need to have an existing Conjur installation in order to use the Conjur
 
 The Conjur Service Broker is an implementation of the [Open Service Broker API](https://www.openservicebrokerapi.org/) (version 2.13).
 
-## Installation Instructions
+#### Table of Contents
+- [Installation](#installation)
+- [Usage](#usage)
+- [Contributing](#contributing)
+- [License](#license)
+
+## <a name="installation"> Installation Instructions
 
 The instructions that follow will guide you through installing the Conjur Service Broker
 and the Conjur Buildpack. The [Conjur Buildpack](https://github.com/cyberark/cloudfoundry-conjur-buildpack)
@@ -131,7 +137,8 @@ deployed to your Cloud Foundry installation.
 
 The Conjur Buildpack uses [Summon](https://cyberark.github.io/summon/) to load secrets into the environment of CF-deployed applications based on the app's `secrets.yml` file. For instructions on installing and using the Conjur Buildpack, please [see the Conjur Buildpack documentation](https://github.com/cyberark/cloudfoundry-conjur-buildpack).
 
-## Service Broker Usage
+
+## <a name="usage"> Service Broker Usage
 
 Once the Service Broker is installed, you should see the service listing from any
 org / space:
@@ -243,12 +250,12 @@ into the running application's environment.
 The secrets are now available to be used by the application, but are not visible
 when you run `cf env my-app` or if you `cf ssh my-app` and run `printenv`.
 
-## Contributing
+## <a name="contributing"> Contributing
 
 Information for developing and testing the service broker can be found in the
 [Contributing Guide](CONTRIBUTING.md).
 
-## License
+## <a name="license"> License
 
 Copyright 2018 CyberArk
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
-The Conjur Service Broker makes it easy for you to secure credentials used by applications deployed in Cloud Foundry (CF) with CyberArk Conjur. Using the Conjur Service Broker, your CF applications will automatically assume a Conjur Host identity on deploy that will enable them to securely access secret values stored in Conjur.
+# CyberArk Conjur Service Broker for Cloud Foundry
 
-You will need to have an existing Conjur installation in order to use the Conjur Service Broker; for more information about installing Conjur, please visit [conjur.org](http://conjur.org) or check out our [GitHub repository](https://github.com/cyberark/conjur).
+The Conjur Service Broker makes it easy to secure credentials used by applications in Cloud Foundry (CF) with CyberArk Conjur. Using the Conjur Service Broker, applications are given a Conjur identity automatically when deployed, allowing them to securely retrieve secrets stored in Conjur.
+
+You need a Conjur installation accessible by Cloud Foundry in order to use the Conjur Service Broker; for more information about installing Conjur, please visit [conjur.org](http://conjur.org) or check out our [GitHub repository](https://github.com/cyberark/conjur).
 
 The Conjur Service Broker is an implementation of the [Open Service Broker API](https://www.openservicebrokerapi.org/) (version 2.13).
 
 #### Table of Contents
+
 - [Installation](#installation)
 - [Usage](#usage)
 - [Contributing](#contributing)
@@ -12,307 +15,373 @@ The Conjur Service Broker is an implementation of the [Open Service Broker API](
 
 ## <a name="installation"> Installation Instructions
 
-The instructions that follow will guide you through installing the Conjur Service Broker
+These instructions guide you through installing the Conjur Service Broker
 and the Conjur Buildpack. The [Conjur Buildpack](https://github.com/cyberark/cloudfoundry-conjur-buildpack)
-is a decorator buildpack that installs [Summon](https://cyberark.github.io/summon/)
-on application start, and uses Summon to securely inject secret values into your
-application's environment. Using the Conjur Buildpack is a convenient way to
+is a decorator buildpack that provides [Summon](https://cyberark.github.io/summon/)
+to Cloud Foundry applications. This allows secrets to be securely injected into your
+application's environment at startup. Using the Conjur Buildpack is a convenient way to
 securely deliver the secrets that your application needs.
 
 The Conjur Buildpack and Conjur Service Broker should be installed by an admin
-Cloud Foundry user. If you follow the instructions below, your CF installation
-will be configured so that CF users in any org / space will be able to see the
+Cloud Foundry user. Follow the instructions below to configure your CF installation
+so that CF users in any org / space are able to see the
 Conjur service listing when they run `cf marketplace`. For more information on how
 to use the Conjur Service Broker when deploying applications, see the
 [usage instructions](#service-broker-usage).
 
 ### Installing the Conjur Service Broker
 
-**Before you begin, ensure you are logged into your CF deployment via the CF CLI.**
+**IMPORTANT:** *Before you begin, ensure you are logged into your CF deployment via the CF CLI as an admin.*
 
-You will need to target the org and space where you want the Service Broker application to run.
+1. **Target the org and space where you want the Service Broker application to run**
 
-Begin by pushing the Service Broker application to CF:
-```
-git clone git@github.com:conjurinc/conjur-service-broker.git
-cd conjur-service-broker
-cf push --no-start --random-route
-```
+    ```sh
+    cf target -o cyberark-conjur -s conjur-service-broker
+    ```
 
-The Conjur Service Broker uses HTTP basic authentication, and the credentials it uses must be stored as environment variables in the Service Broker app:
-```
-cf set-env conjur-service-broker SECURITY_USER_NAME [value]
-cf set-env conjur-service-broker SECURITY_USER_PASSWORD [value]
-```
+2. **Clone and push the Service Broker application**
 
-To configure the Service Broker to communicate with your external Conjur instance, the Service Broker app requires the following environment variables:
-- `CONJUR_VERSION`: the version of your Conjur instance (`4` or `5`); defaults to 5.
+    ```sh
+    git clone git@github.com:conjurinc/conjur-service-broker.git
+    cd conjur-service-broker
+    cf push --no-start --random-route
+    ```
 
-- `CONJUR_ACCOUNT`: the account name for the Conjur instance you are connecting to.
+3. **Configure the Service Broker application**
 
-- `CONJUR_APPLIANCE_URL`: the URL of the Conjur appliance instance you are connecting to. When using an HA Conjur master cluster, this should be the URL of the master load balancer.
+    The Conjur Service Broker uses HTTP basic authentication, and the credentials it uses must be stored as environment variables in the Service Broker app:
 
-- `CONJUR_FOLLOWER_URL` (HA only): If using high availability, this should be the URL for a load balancer that manages the cluster's Follower instances. This is the URL that applications that bind to the service broker will use to communicate with Conjur.
+    > **NOTE:** The username and password may be any values you choose. These are used by the Service Broker to verify
+    > that requests are coming from the Cloud Foundry foundation.
 
-- `CONJUR_POLICY`: the Policy where new Hosts should be added - the Conjur account specified in `CONJUR_AUTHN_LOGIN` needs `create` and `update` privilege on this Policy.
-  > **NOTE:** The `CONJUR_POLICY` is optional, but is strongly recommended. By default, if this value is not specified, Hosts will be added to the `root` Conjur policy, and the Conjur account that the Service Broker uses to manage the Hosts will need `create` and `update` privileges on the `root` Conjur policy.
+    ```
+    cf set-env conjur-service-broker SECURITY_USER_NAME [value]
+    cf set-env conjur-service-broker SECURITY_USER_PASSWORD [value]
+    ```
 
-  > **NOTE:** If you use multiple CloudFoundry foundations, this policy should include an identifier for the foundation to distinguish applications deployed in each. For example, if you have both a `production` and `development` foundation, then your policy branches for the Conjur Service Broker might be `cf/prod` and `cf/dev`.
+    To configure the Service Broker to communicate with your external Conjur instance, the Service Broker app requires the following environment variables:
 
-  > **NOTE:** If you are using v4 Conjur, the Service Broker requires your `CONJUR_POLICY` to have a Host Factory called `CONJUR_POLICY-apps`. For example, if your `CONJUR_POLICY` is `cf/prod`, you can add a Host Factory by updating your  policy file to include the following:
-  > ```yaml
-  > - !policy
-  >   id: cf
-  >   body:
-  >     - !policy prod
-  >       owner: !group cf-admin-group
-  >       body:
-  >       - !layer cf/prod-apps
-  > 
-  >       - !host-factory
-  >         id: cf/prod-apps
-  >         layers: [ !layer cf/prod-apps ]
-  > ```
-  > 
-  > If you do not specify a `CONJUR_POLICY` (this is not recommended) in your Service Broker configuration and you are using > `CONJUR_VERSION` 4, then you will need to add a Host Factory to the `root` Conjur policy by including:
-  > ```yaml
-  > - !layer apps
-  > 
-  > - !host-factory
-  >   id: apps
-  >   layers: [ !layer apps ]
-  > ```
-  > 
+    - `CONJUR_VERSION`:
+      the version of your Conjur instance (`4` or `5`); defaults to 5.
 
-- `CONJUR_AUTHN_LOGIN`: the identity of a Conjur Host (of the form `host/host-id`) with `create` and `update` privileges on `CONJUR_POLICY`. This account will be used to add and remove Hosts from Conjur policy as apps are deployed to or removed from PCF.
+    - `CONJUR_ACCOUNT`:
+      the account name for the Conjur instance you are connecting to.
 
-  If you are using Enterprise Conjur, you will want to add an annotation on the Service Broker Host in policy to indicate which platform the Service Broker will be used on. The policy you load may look something like:
-  ```yaml
-  - !host
-    id: cf-service-broker
-    annotations:
-      platform: cloudfoundry
-  ```
-  You may elect to set `platform` to `cloudfoundry` or to `pivotalcloudfoundry`, for example. This annotation will be used to set annotations on Hosts added by the Service Broker, so that they will show in the Conjur UI with the appropriate platform logo.
+    - `CONJUR_APPLIANCE_URL`:
+      the URL of the Conjur appliance instance you are connecting to. When using an HA Conjur master cluster, this should be the URL of the master load balancer.
 
-  > **NOTE:** The `CONJUR_AUTHN_LOGIN` value for the Host created in policy above is `host/cf-service-broker`.
+    - `CONJUR_FOLLOWER_URL` (HA only):
+      If using high availability, this should be the URL of a load balancer for the cluster's Follower instances. This is the URL that applications use to communicate with Conjur.
 
-- `CONJUR_AUTHN_API_KEY`: the API Key of the Conjur Host whose identity you have provided in `CONJUR_AUTHN_LOGIN`.
+    - `CONJUR_POLICY`:
+      the Policy branch where new Host identities should be added. The Conjur identity specified in `CONJUR_AUTHN_LOGIN` must have `create` and `update` permissions on this policy branch.
 
-- `CONJUR_SSL_CERTIFICATE`: the x509 certificate that was created when Conjur was initiated; this is required for v4 Conjur, but is optional otherwise. If the certificate is stored in a PEM file, you can load it into a local environment variable by calling `export CONJUR_SSL_CERTIFICATE="$(cat tmp/conjur.pem)"`.
+      > **NOTE:** The `CONJUR_POLICY` is optional, but is *strongly* recommended. If this value is not specified, the Service Broker uses the `root` Conjur policy.
 
-- `ENABLE_SPACE_IDENTITY`: When set to the value `true`, the service broker will provide applications with a Space-level `host` identity, rather than create a new `host` identity for the application in Conjur at bind time. This allows the broker to use a Conjur follower for application binding, rather than the Conjur master.
+      > **NOTE:** If you use multiple CloudFoundry foundations, this policy branch should include an identifier for the foundation to distinguish applications deployed in each foundation. For example, if you have both a `production` and `development` foundation, then your policy branches for each Conjur Service Broker might be `cf/prod` and `cf/dev`.
 
-To load these environment variables into the Service Broker's environment, run:
-```
-cf set-env conjur-service-broker CONJUR_VERSION [value]
-cf set-env conjur-service-broker CONJUR_ACCOUNT [value]
-cf set-env conjur-service-broker CONJUR_APPLIANCE_URL [value]
-cf set-env conjur-service-broker CONJUR_AUTHN_LOGIN [value]
-cf set-env conjur-service-broker CONJUR_AUTHN_API_KEY [value]
-cf set-env conjur-service-broker CONJUR_POLICY [value]
-cf set-env conjur-service-broker CONJUR_SSL_CERTIFICATE [value]
-cf set-env conjur-service-broker ENABLE_SPACE_IDENTITY [value]
-```
+      > **NOTE:** If you are using v4 Conjur, the Service Broker requires your `CONJUR_POLICY` to have a Host Factory called `CONJUR_POLICY-apps`. For example, if your `CONJUR_POLICY` is `cf/prod`, you can add a Host Factory by updating your  policy file to include the following:
+      > ```yaml
+      > - !policy
+      >   id: cf
+      >   body:
+      >     - !policy prod
+      >       owner: !group cf-admin-group
+      >       body:
+      >       - !layer cf/prod-apps
+      > 
+      >       - !host-factory
+      >         id: cf/prod-apps
+      >         layers: [ !layer cf/prod-apps ]
+      > ```
+      > 
+      > If you do not specify a `CONJUR_POLICY` (this is not recommended) in your Service Broker configuration and you are using > `CONJUR_VERSION` 4, then you need to add a Host Factory to the `root` Conjur policy by including:
+      > ```yaml
+      > - !layer apps
+      > 
+      > - !host-factory
+      >   id: apps
+      >   layers: [ !layer apps ]
+      > ```
+      > 
 
-Once the Service Broker is configured, start the Service Broker application
-```
-cf start conjur-service-broker
-```
-and register it with the same Basic Auth credentials specified in your environment variables:
-```
-APP_URL="http://`cf app conjur-service-broker | grep -E -w 'urls:|routes:' | awk '{print $2}'`"
-cf create-service-broker conjur-service-broker "[username value]" "[password value]" $APP_URL
-```
-When the Service Broker application is started, it will run a health check that validates its connection to your Conjur instance, including checking that the Host Factory exists if you are using Conjur version 4.
+    - `CONJUR_AUTHN_LOGIN`:
+      the identity of a Conjur Host (of the form `host/host-id`) with `create` and `update` privileges on `CONJUR_POLICY`. This account is used to add and remove Hosts from Conjur policy as apps are deployed to or removed from PCF.
 
-To make the Conjur service listing available in the marketplace in all orgs and spaces, run
-```
-cf enable-service-access cyberark-conjur
-```
+      If you are using Enterprise Conjur, you should add an annotation on the Service Broker Host in policy to indicate which platform the Service Broker is used on. The policy you load should similar to:
+      ```yaml
+      - !host
+        id: cf-service-broker
+        annotations:
+          platform: cloudfoundry
+      ```
+      You may elect to set `platform` to `cloudfoundry` or to `pivotalcloudfoundry`, for example. This annotation is used to set annotations on Hosts added by the Service Broker, so that they show in the Conjur UI with the appropriate platform logo.
 
-If you have reached this point, the Conjur Service Broker has been successfully
-deployed to your Cloud Foundry installation.
+      > **NOTE:** The `CONJUR_AUTHN_LOGIN` value for the Host created in policy above is `host/cf-service-broker`.
+
+    - `CONJUR_AUTHN_API_KEY`:
+      the API Key of the Conjur Host whose identity you have provided in `CONJUR_AUTHN_LOGIN`.
+
+    - `CONJUR_SSL_CERTIFICATE`: 
+      the PEM-encoded x509 CA certificate chain for Conjur. This is required if your Conjur installation uses SSL (e.g. Conjur Enterprise).
+
+        This value may be obtained by running the command:
+
+        ```sh-session
+        $ openssl s_client -showcerts -servername [CONJUR_DNS_NAME] \
+            -connect [CONJUR_DNS_NAME]:443 < /dev/null 2> /dev/null \
+            | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p'
+        -----BEGIN CERTIFICATE-----
+        ...
+        -----END CERTIFICATE-----
+        ```
+
+    - `ENABLE_SPACE_IDENTITY`:
+      When set to the value `true`, the service broker provides applications with a Space-level `host` identity, rather than create a new `host` identity for the application in Conjur at bind time. This allows the broker to use a Conjur follower for application binding, rather than the Conjur master.
+
+    To load these environment variables into the Service Broker's environment, run:
+    ```
+    cf set-env conjur-service-broker CONJUR_VERSION [value]
+    cf set-env conjur-service-broker CONJUR_ACCOUNT [value]
+    cf set-env conjur-service-broker CONJUR_APPLIANCE_URL [value]
+    cf set-env conjur-service-broker CONJUR_AUTHN_LOGIN [value]
+    cf set-env conjur-service-broker CONJUR_AUTHN_API_KEY [value]
+    cf set-env conjur-service-broker CONJUR_POLICY [value]
+    cf set-env conjur-service-broker CONJUR_SSL_CERTIFICATE [value]
+    cf set-env conjur-service-broker ENABLE_SPACE_IDENTITY [value]
+    ```
+
+4. **Start the Service Broker application**
+
+    ```sh
+    cf start conjur-service-broker
+    ```
+
+    > **NOTE:** When the Service Broker application is started, it runs a health
+    > check that validates its connection to your Conjur instance, including
+    > checking that the Host Factory exists if you are using Conjur version 4.
+
+5. **Register the Service Broker in Cloud Foundry**
+
+    Use the same Basic Auth credentials specified in your environment variables:
+
+    ```sh
+    APP_URL="http://`cf app conjur-service-broker | grep -E -w 'urls:|routes:' | awk '{print $2}'`"
+    cf create-service-broker conjur-service-broker "[username value]" "[password value]" $APP_URL
+    ```
+
+6. **List the Conjust service in the marketplace for all Orgs and Spaces**
+
+    ```
+    cf enable-service-access cyberark-conjur
+    ```
+
+The CyberArk Conjur Service Broker is now installed and ready to use!
 
 ### Installing the Conjur Buildpack
 
-The Conjur Buildpack uses [Summon](https://cyberark.github.io/summon/) to load secrets into the environment of CF-deployed applications based on the app's `secrets.yml` file. For instructions on installing and using the Conjur Buildpack, please [see the Conjur Buildpack documentation](https://github.com/cyberark/cloudfoundry-conjur-buildpack).
+The Conjur Buildpack uses [Summon](https://cyberark.github.io/summon/) to load secrets into the environment of CF-deployed applications using the app's `secrets.yml` file. 
 
+For instructions on installing and using the Conjur Buildpack, please [see the Conjur Buildpack documentation](https://github.com/cyberark/cloudfoundry-conjur-buildpack).
 
 ## <a name="usage"> Service Broker Usage
 
-Once the Service Broker is installed, you should see the service listing from any
-org / space:
-```
-$ cf marketplace
-Getting services from marketplace in org cyberark-conjur-org / space cyberark-conjur-space as admin...
-OK
+### Creating a Conjur Service Instance
 
-service             plans                  description
-cyberark-conjur     community              An open source security service that provides secrets management, machine-identity based authorization, and more.
+1. **Confirm Conjur Service is in the Marketplace**
 
-TIP:  Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service.
-```
+    Once the Service Broker is installed, you should see the service listing from any
+    org / space:
 
-When you are ready to use the Conjur Service Broker, you can create a Conjur
-service instance under the `community` plan in the org / space where you will be
-deploying your application:
-```
-cf create-service cyberark-conjur community conjur
-```
+    ```sh-session
+    $ cf marketplace
+    Getting services from marketplace in org cyberark-conjur-org / space cyberark-conjur-space as admin...
+    OK
 
-> **NOTE:** Service instances cannot be shared between spaces. A Conjur
-service instance must be created in each space where apps retrieve secrets
-from Conjur.
+    service             plans                  description
+    cyberark-conjur     community              An open source security service that provides secrets management, machine-identity based authorization, and more.
 
-For PCF 2.0+, when the service broker is provisioned in a space, it will automatically create
-a policy branch for the org and space if it doesn't already exist. The policy will look similar to
-this:
+    TIP:  Use 'cf marketplace -s SERVICE' to view descriptions of individual plans of a given service.
+    ```
 
-```yaml
----
-# Policy for the Organization
-- !policy
-  # Organization GUID from PCF.
-  # This may be obtained by running `cf org --guid {org name}
-  id: cbd7a05a-b304-42a9-8f66-6827ae6f78a1
-  body:
-    # Layer to allow privileging an entire organzation to a resource
-    - !layer
+2. **Create a Conjur Service Instance**
 
-    # Policy for the Space
+    When you are ready to use the Conjur Service Broker, you can create a Conjur
+    service instance under the `community` plan in the org / space where you are
+    deploying your application:
+    ```
+    cf create-service cyberark-conjur community conjur
+    ```
+
+    > **NOTE:** Service instances cannot be shared between spaces. A Conjur
+    service instance must be created in each space where apps retrieve secrets
+    from Conjur.
+
+    For PCF 2.0+, when the service broker is provisioned in a space, it automatically creates
+    a policy branch for the org and space if it doesn't already exist. The policy looks similar to
+    this:
+
+    ```yaml
+    ---
+    # Policy for the Organization
     - !policy
-      # Space GUID from PCF.
-      # This may be obtained by running `cf space --guid {space name}
-      id: 8bf39f4a-ebde-437b-9c38-3d234b80631a
+      # Organization GUID from PCF.
+      # This may be obtained by running `cf org --guid {org name}
+      id: cbd7a05a-b304-42a9-8f66-6827ae6f78a1
       body:
-        # Layer to allow privileging an entire space to a resource
-        # The service broker will add applications to this layer automatically.
+        # Layer to privilege an entire organzation to a resource
         - !layer
 
-    # Grant to add the Space layer to the Org Layer
-    - !grant
-      role: !layer
-      member: !layer 8bf39f4a-ebde-437b-9c38-3d234b80631a
-```
+        # Policy for the Space
+        - !policy
+          # Space GUID from PCF.
+          # This may be obtained by running `cf space --guid {space name}
+          id: 8bf39f4a-ebde-437b-9c38-3d234b80631a
+          body:
+            # Layer to privilege an entire space to a resource
+            # The service broker adds applications to this layer automatically.
+            - !layer
 
-### Create a `secrets.yml` File
+        # Grant to add the Space layer to the Org Layer
+        - !grant
+          role: !layer
+          member: !layer 8bf39f4a-ebde-437b-9c38-3d234b80631a
+    ```
 
-To leverage the Conjur Buildpack so that secret values will automatically be
-injected into your application's environment at runtime, a `secrets.yml` file is
-required. The `secrets.yml` file gives a mapping of **environment variable name**
-to a **location where a secret is stored in Conjur**. For more information about
-creating this file, [see the Summon documentation](https://cyberark.github.io/summon/#secrets.yml).
+### Using Conjur with a Cloud Foundry Application
 
-### Bind Your Application to the Conjur Service
+1. **Create a `secrets.yml` File**
 
-Binding your application to the `conjur` service instance provides the application with an
-identity in Conjur, and credentials that it may use to retrieve secrets.
+    To leverage the Conjur Buildpack so that secret values are automatically
+    injected into your application's environment at runtime, your application needs
+    a `secrets.yml` file is. The `secrets.yml` file gives a mapping of **environment variable name**
+    to a **location where a secret is stored in Conjur**. For more information about
+    creating this file, [see the Summon documentation](https://cyberark.github.io/summon/#secrets.yml).
 
-To bind your application to the `conjur` service using the CLI, run the command:
-```
-cf bind-service my-app conjur
-```
+2. **Bind Your Application to the Conjur Service**
 
-Alternatively you can specify the conjur service in your application manifest:
-```
----
-applications:
-- name: my-app
-  services:
-  - conjur
-```
+    Binding your application to the `conjur` service instance provides the application with an
+    identity in Conjur, and credentials that it may use to retrieve secrets.
 
-#### Application vs Space Host Identity
+    - **Using the Cloud Foundry CLI**
 
-The service broker may be configured to either create a single Conjur identity shared by
-all applications in a space, or to create a Conjur identity for each application
-separately.
+        To bind your application to the `conjur` service using the CLI, run the command:
+        ```
+        cf bind-service my-app conjur
+        ```
 
-In PCF version 2.0+, when the service broker creates the identity for your application
-in Conjur, it will automatically add it to a Conjur Layer representing the `Organization`
-and `Space` where the application is deployed. These layers may be used for control secret
-access at the org or space level, rather than the application host itself.
+    - **Using the Application Manifest**
 
-##### Space-scoped Identity
+        Alternatively you can specify the conjur service in your application manifest:
+        ```
+        ---
+        applications:
+        - name: my-app
+          services:
+          - conjur
+        ```
 
-Space-scoped identities are enabled by configuring the service broker with
-`ENABLE_SPACE_IDENTITY` set to `true`. This means that when a service instance is created
-in a space, the service broker will create a Conjur Host for that space. When an application
-is bound to the service, the service broker will give it the credentials of the space identity,
-rather than create a new host identity for the application.
+    #### Application vs Space Host Identity
 
-The advantage to this is the bind operation only requires access to a Conjur follower and
-not the Conjur master. This promotes high-availability and scalability of app binding and secret
-retrieval.
+    When an application is bound to the Conjur service, it receives an identity in Conjur
+    and credentials to authenticate to Conjur.
 
-##### Application-scoped Identity
+    The service broker may be configured to either create a single Conjur identity shared by
+    all applications in a space, or to create a Conjur identity for each application
+    separately.
 
-When space identities are not enabled, the service broker will create a new Conjur host identity
-for each application bound to the service. This requires that the service broker is able to
-communicate with the Conjur master for each bind request.
+    In PCF version 2.0+, when the service broker creates the identity for your application
+    in Conjur, it automatically adds it to a Conjur Layer representing the `Organization`
+    and `Space` where the application is deployed. These layers may be used for control secret
+    access at the org or space level, rather than the application host itself.
 
-The advantage to this is finer-grained access control and audit logs in Conjur.
+    ##### Space-scoped Identity
 
-### Granting Application Access to Secrets
+    Space-scoped identities are enabled by configuring the service broker with
+    `ENABLE_SPACE_IDENTITY` set to `true`. This means that when a service instance is created
+    in a space, the service broker creates a Conjur Host for that space. When an application
+    is bound to the service, the service broker gives it the credentials of the space identity,
+    rather than create a new host identity for the application.
 
-PCF applications can be granted access to secrets using either the Org and Space layers,
-or with the application host identity.
+    The advantage to this is the bind operation only requires access to a Conjur follower and
+    not the Conjur master. This promotes high-availability and scalability of app binding and secret
+    retrieval.
 
-#### Privilege Org and Space Layers
+    ##### Application-scoped Identity
 
-Applications can be granted access to secrets by privileging the Org or Space layers
-to read secrets using Conjur policy.
+    When space identities are not enabled, the service broker creates a new Conjur host identity
+    for each application bound to the service. This requires that the service broker is able to
+    communicate with the Conjur master for each bind request.
 
-The layer Ids use the Org and Space GUID identifiers, which may be obtained
-using the Cloud Foundry CLI:
-```sh-session
-$ cf org --guid <org-name>
-6b40649e-331b-424d-afa0-6d569f016f51
+    The advantage to this is finer-grained access control and audit logs in Conjur.
 
-$ cf space --guid <space-name>
-72a928f6-bf7c-4732-a195-896f67bd1133
-```
+3. **Permit the Application to Access Secrets in Conjur**
 
-For example, the policy to privilege a space to access a secret is:
-```yaml
-- !permit
-  resource: my-secret-id
-  role: !layer cf/prod/6b40649e-331b-424d-afa0-6d569f016f51/72a928f6-bf7c-4732-a195-896f67bd1133
-  privileges: [ read, execute ]
-```
+    PCF applications can be granted access to secrets using either the Org and Space layers,
+    or with the application host identity.
 
-#### Privilege Application Host Identity
+    #### Privilege Org and Space Layers
 
-> **NOTE:** Application Host privileging is not available when using Space Host Identies.
+    Applications can be granted access to secrets by privileging the Org or Space layers
+    to read secrets using Conjur policy.
 
-After your application has been pushed to PCF, you can use its host identity in
-Conjur policy to grant it access to secrets.
+    The layer Ids use the Org and Space GUID identifiers, which may be obtained
+    using the Cloud Foundry CLI:
+    ```sh-session
+    $ cf org --guid <org-name>
+    6b40649e-331b-424d-afa0-6d569f016f51
 
-The host identity of the application is stored in the `authn_login` field in the `cyberark-conjur`
-credentials in the application's environment, and might look something like
-`host/cf/prod/0299a19d-7de4-4e98-89f6-372ac7c0521f`.
+    $ cf space --guid <space-name>
+    72a928f6-bf7c-4732-a195-896f67bd1133
+    ```
 
-  > **NOTE**: In PCF version 2.0+, the host identity will include the Organization and Space GUIDs in
-  the Host identity, for example:
+    For example, the policy to privilege a space to access a secret is:
+    ```yaml
+    - !permit
+      resource: my-secret-id
+      role: !layer cf/prod/6b40649e-331b-424d-afa0-6d569f016f51/72a928f6-bf7c-4732-a195-896f67bd1133
+      privileges: [ read, execute ]
+    ```
 
-  ```
-  host/cf/prod/cbd7a05a-b304-42a9-8f66-6827ae6f78a1/8bf39f4a-ebde-437b-9c38-3d234b80631a/c363669e-e43b-40b9-b650-493d3bdb4663
-  ```
+    #### Privilege Application Host Identity
 
-### Run Your Application
+    > **NOTE:** Application Host privileging is not available when using Space Host Identies.
 
-Now that your application is privileged to access the secrets it needs in Conjur,
-start or restage the app so that the Conjur Buildpack can inject the secret values
-into the running application's environment.
+    After your application has been pushed to PCF, you can use its host identity in
+    Conjur policy to grant it access to secrets.
+
+    The host identity of the application is stored in the `authn_login` field in the `cyberark-conjur`
+    credentials in the application's environment, and might look something like
+    `host/cf/prod/0299a19d-7de4-4e98-89f6-372ac7c0521f`.
+
+      > **NOTE**: In PCF version 2.0+, the host identity includes the Organization and Space GUIDs in
+      the Host identity, for example:
+
+      ```
+      host/cf/prod/cbd7a05a-b304-42a9-8f66-6827ae6f78a1/8bf39f4a-ebde-437b-9c38-3d234b80631a/c363669e-e43b-40b9-b650-493d3bdb4663
+      ```
+
+4. **Run Your Application**
+
+    Now that your application is privileged to access the secrets it needs in Conjur,
+    start or restage the app so that the Conjur Buildpack can inject the secret values
+    into the running application's environment.
+
+    ```sh
+    cf start my-app
+
+    # or
+
+    cf restage my-app
+    ```
 
 The secrets are now available to be used by the application, but are not visible
 when you run `cf env my-app` or if you `cf ssh my-app` and run `printenv`.
 
 ### Rotating Host API Keys
 
-When the API key for a PCF application host is rotated, the application will need to be rebound
-to the Conjur service instance to receive the new credentials, and then restaged to fetch secret
+When the API key for a PCF application host is rotated, the application needs to be re-bound
+to the Conjur service instance to receive the new credentials, and then re-staged to fetch secret
 values using the new credentials.
 
 > **NOTE:** When using Space Host Identities, the new API key for the Space Host needs to be updated
@@ -324,13 +393,13 @@ conjur variable values add "<cf policy root>/<org-guid>/<space-guid>/space-host-
 conjur variable values add "cf/prod/6b40649e-331b-424d-afa0-6d569f016f51/72a928f6-bf7c-4732-a195-896f67bd1133/space-host-api-key" "1p9c5443sy1bg93ek2e062wsnmvy3p9k9j83nq841sj1sp2vasze1r"
 ```
 
-To rebind the application to Conjur, run these commands using the Cloud Foundry CLI:
+To re-bind the application to Conjur, run these commands using the Cloud Foundry CLI:
 ```sh
 cf unbind-service <app-name> conjur
 cf bind-service <app-name> conjur
 ```
 
-To restage the application, run this command:
+To re-stage the application, run this command:
 ```
 cf restage <app-name>
 ```

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -32,7 +32,7 @@ function install_buildpack() {
     cf api "$CF_API_ENDPOINT" --skip-ssl-validation
     CF_PASSWORD=$CF_ADMIN_PASSWORD cf auth admin
 
-    if ! cf buildpacks | grep "conjur_buildpack"; then
+    if ! cf buildpacks | grep -w "conjur_buildpack"; then
         # get the Conjur buildpack and upload to cf
         mkdir conjur-buildpack
         pushd conjur-buildpack


### PR DESCRIPTION
Connected to #116 

This PR makes the following updates to the README documentation:

* Add section on privileging applications using the org/space layers or the application host identity.
* Include considerations when using Space Host Identities.
* Add section on rotating host API keys.