### PR TITLE
Switch OrgSpacePolicy to use Follower URL if configured

### DIFF
--- a/app/models/org_space_policy.rb
+++ b/app/models/org_space_policy.rb
@@ -44,7 +44,7 @@ class OrgSpacePolicy
   end
 
   def org_policy
-    conjur_api.resource(org_policy_id)
+    ConjurClient.readonly_api.resource(org_policy_id)
   end
 
   def org_policy_id
@@ -56,7 +56,7 @@ class OrgSpacePolicy
   end
 
   def space_policy
-    conjur_api.resource(space_policy_id)
+    ConjurClient.readonly_api.resource(space_policy_id)
   end
 
   def space_policy_id
@@ -68,7 +68,7 @@ class OrgSpacePolicy
   end
 
   def space_layer
-    conjur_api.resource(space_layer_id)
+    ConjurClient.readonly_api.resource(space_layer_id)
   end
 
   def space_layer_id

--- a/app/models/service_binding/conjur_v5_space_binding.rb
+++ b/app/models/service_binding/conjur_v5_space_binding.rb
@@ -15,7 +15,7 @@ module ServiceBinding
     end
 
     def create
-      host = api.role(role_name)
+      host = ConjurClient.readonly_api.role(role_name)
 
       raise HostNotFound, "No space host identity found." unless host.exists?
 
@@ -35,7 +35,7 @@ module ServiceBinding
     end
 
     def api_key
-      api_key_variable = api.resource(api_key_name)
+      api_key_variable = ConjurClient.readonly_api.resource(api_key_name)
 
       raise ApiKeyNotFound unless api_key_variable.exists?
 
@@ -48,13 +48,6 @@ module ServiceBinding
         'variable',
         "#{policy_base}#{@org_guid}/#{@space_guid}/space-host-api-key"
       ].join(':')
-    end
-
-    # The space host binding uses the application Conjur URl so that
-    # if the follower URL is configured, the bind operation will use
-    # the follower, rather than the master, to perform this operation.
-    def api
-      @api ||= ConjurClient.new.api(ConjurClient.application_conjur_url)
     end
   end
 end

--- a/lib/conjur_client.rb
+++ b/lib/conjur_client.rb
@@ -11,6 +11,12 @@ class ConjurClient
       ConjurClient.new.api(appliance_url)
     end
 
+    # Returns an API object that may be read-only. It will use
+    # the Conjur Follower URL when available.
+    def readonly_api
+      ConjurClient.new.api(ConjurClient.application_conjur_url)
+    end
+
     def v4_host_factory_id
       if policy == "root"
         "#{account}:host_factory:apps"

--- a/spec/lib/conjur_client_spec.rb
+++ b/spec/lib/conjur_client_spec.rb
@@ -2,6 +2,57 @@ require 'spec_helper'
 require 'conjur_client'
 
 describe ConjurClient do
+  describe "#api" do
+    let(:master_url) { "master" }
+    let(:follower_url) { "follower" }
+    
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+
+      allow(ENV).to receive(:[]).with('CONJUR_APPLIANCE_URL').and_return(master_url)
+      allow(ENV).to receive(:[]).with('CONJUR_FOLLOWER_URL').and_return(follower_url)
+    end
+
+    it "returns a Conjur API object" do
+      expect(ConjurClient.api).to be_instance_of(Conjur::API)
+    end
+
+    it "uses the Conjur Master URL" do
+      ConjurClient.api
+      expect(Conjur.configuration.appliance_url).to equal(master_url)
+    end
+  end
+
+  describe "#readonly_api" do
+    let(:master_url) { "master" }
+    let(:follower_url) { nil }
+    
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+
+      allow(ENV).to receive(:[]).with('CONJUR_APPLIANCE_URL').and_return(master_url)
+      allow(ENV).to receive(:[]).with('CONJUR_FOLLOWER_URL').and_return(follower_url)
+    end
+
+    it "returns a Conjur API object" do
+      expect(ConjurClient.readonly_api).to be_instance_of(Conjur::API)
+    end
+
+    it "uses the Conjur Master URL" do
+      ConjurClient.readonly_api
+      expect(Conjur.configuration.appliance_url).to equal(master_url)
+    end
+
+    context "when the follower URL is configured" do
+      let(:follower_url) { "follower" }
+
+      it "uses the Conjur Follower URL" do
+        ConjurClient.readonly_api
+        expect(Conjur.configuration.appliance_url).to equal(follower_url)
+      end
+    end
+  end
+
   describe "login_host_id" do
     context "login is a host" do
       before do


### PR DESCRIPTION
Connected to #121 

This PR updates the Org and Space policy checks to use the follower URL if configured.