### PR TITLE
Fetch CI environment URLs via summon

### DIFF
--- a/secrets.yml
+++ b/secrets.yml
@@ -1,7 +1,7 @@
 PCF_CONJUR_ACCOUNT: pcf
-PCF_CONJUR_APPLIANCE_URL: https://conjur-pcf.itd.conjur.net
+PCF_CONJUR_APPLIANCE_URL: !var ci/pcf/conjur-appliance-url
 PCF_CONJUR_USERNAME: !var ci/pcf/conjur-admin-user
 PCF_CONJUR_API_KEY: !var ci/pcf/conjur-admin-key
 
-CF_API_ENDPOINT: https://api.sys.pcf.itd.conjur.net
+CF_API_ENDPOINT: !var ci/pcf/api-url
 CF_ADMIN_PASSWORD: !var ci/pcf/admin-cli-password


### PR DESCRIPTION
Connected to https://github.com/conjurinc/cloudfoundry-conjur-tile/issues/32

This PR removes the CI environment URLs from `secrets.yml` and pulls them via Summon as well.