### PR TITLE
Update rails gems to 5.2.4.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,9 @@ git_source(:github) do |repo_name|
 end
 
 gem 'conjur-api', '~> 5.3.1'
-gem 'activesupport', '~> 5.2.1'
-gem 'railties', '~> 5.2.2.1'
-gem 'actionview', '~> 5.2.2.1'
+gem 'activesupport', '~> 5.2.4.2'
+gem 'railties', '~> 5.2.4.2'
+gem 'actionview', '~> 5.2.4.2'
 gem 'rack', '~> 2.0.8'
 gem 'json-schema', '~> 2.8'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (5.2.2.1)
-      actionview (= 5.2.2.1)
-      activesupport (= 5.2.2.1)
-      rack (~> 2.0)
+    actionpack (5.2.4.2)
+      actionview (= 5.2.4.2)
+      activesupport (= 5.2.4.2)
+      rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.2.1)
-      activesupport (= 5.2.2.1)
+    actionview (5.2.4.2)
+      activesupport (= 5.2.4.2)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activesupport (5.2.2.1)
+    activesupport (5.2.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -28,7 +28,7 @@ GEM
       ffi (~> 1.9.10)
       rspec-expectations (>= 2.99)
       thor (~> 0.19)
-    builder (3.2.3)
+    builder (3.2.4)
     byebug (10.0.2)
     childprocess (0.9.0)
       ffi (~> 1.0, >= 1.0.11)
@@ -38,12 +38,12 @@ GEM
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
     coderay (1.1.2)
-    concurrent-ruby (1.1.5)
+    concurrent-ruby (1.1.6)
     conjur-api (5.3.1)
       activesupport
       rest-client
     contracts (0.16.0)
-    crass (1.0.5)
+    crass (1.0.6)
     cucumber (2.99.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -58,12 +58,12 @@ GEM
     diff-lcs (1.3)
     domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
-    erubi (1.8.0)
+    erubi (1.9.0)
     ffi (1.9.25)
     gherkin (4.1.3)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.6.0)
+    i18n (1.8.2)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
@@ -81,7 +81,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.3.1)
+    loofah (2.4.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (0.9.2)
@@ -89,11 +89,11 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.14.0)
     multi_json (1.13.1)
     multi_test (0.1.2)
     netrc (0.11.0)
-    nokogiri (1.10.8)
+    nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     parslet (1.8.2)
     pry (0.11.3)
@@ -104,17 +104,17 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.2)
     puma (3.12.4)
-    rack (2.0.8)
+    rack (2.0.9)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
-    railties (5.2.2.1)
-      actionpack (= 5.2.2.1)
-      activesupport (= 5.2.2.1)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
+    railties (5.2.4.2)
+      actionpack (= 5.2.4.2)
+      activesupport (= 5.2.4.2)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
@@ -160,7 +160,7 @@ GEM
     thread_safe (0.3.6)
     toml (0.2.0)
       parslet (~> 1.8.0)
-    tzinfo (1.2.5)
+    tzinfo (1.2.6)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -174,8 +174,8 @@ PLATFORMS
   x86_64-darwin-18
 
 DEPENDENCIES
-  actionview (~> 5.2.2.1)
-  activesupport (~> 5.2.1)
+  actionview (~> 5.2.4.2)
+  activesupport (~> 5.2.4.2)
   aruba
   byebug
   ci_reporter_rspec (~> 1)
@@ -188,7 +188,7 @@ DEPENDENCIES
   pry-byebug
   puma (~> 3.12)
   rack (~> 2.0.8)
-  railties (~> 5.2.2.1)
+  railties (~> 5.2.4.2)
   rest-client
   rspec (~> 3)
   rspec-rails (~> 3.7)
@@ -197,4 +197,4 @@ DEPENDENCIES
   spring-watcher-listen (~> 2.0.0)
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
This updates ActionView to 5.2.4.2 to address
https://nvd.nist.gov/vuln/detail/CVE-2020-5267