### PR TITLE
Fixable and total trivy scans

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,7 +31,7 @@ pipeline {
       parallel {
         stage('Scan Docker image for fixable issues') {
           steps {
-            scanAndReport("conjur-service-broker", "NONE", false)
+            scanAndReport("conjur-service-broker", "HIGH", false)
           }
         }
         stage('Scan Docker image for all issues') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,17 @@ pipeline {
     }
 
     stage('Scan Docker image') {
-      steps {
-        scanAndReport("conjur-service-broker", "NONE")
+      parallel {
+        stage('Scan Docker image for fixable issues') {
+          steps {
+            scanAndReport("conjur-service-broker", "NONE", false)
+          }
+        }
+        stage('Scan Docker image for all issues') {
+          steps {
+            scanAndReport("conjur-service-broker", "NONE", true)
+          }
+        }
       }
     }
 


### PR DESCRIPTION
Adds an additional trivy report. The new one reports only fixable issues while the original report that contains all issues detected remains as well. Build failures will only occur for HIGH and CRITICAL issues that have fixes available. 