### PR TITLE
Remove test/development gems from main Docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- Removed unused development and test gems from main image
 
 ## [1.1.1] - 2020-01-29
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ WORKDIR /app
 COPY Gemfile /app/
 COPY Gemfile.lock /app/
 
-RUN bundle install
+RUN bundle install --without development test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,8 @@
 FROM conjur-service-broker
 
+# Install all the dependencies (including test/dev ones)
+RUN bundle install --with development test
+
 RUN apt-get install -y apt-transport-https ca-certificates openssl
 
 # Install the Cloud Foundry CLI

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'railties', '~> 5.2.4.2'
 gem 'actionview', '~> 5.2.4.2'
 gem 'rack', '~> 2.0.8'
 gem 'json-schema', '~> 2.8'
+gem 'listen', '>= 3.0.5', '< 3.2'
 
 # Use Puma as the app server
 gem 'puma', '~> 3.12'
@@ -34,7 +35,6 @@ end
 
 group :development do
   gem 'license_finder'
-  gem 'listen', '>= 3.0.5', '< 3.2'
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'


### PR DESCRIPTION
We were installing the development and test gems in the main container and in the test container, which was causing trivy warnings on the main container. This change removes the extra gems from the main container. During testing the changes, we found that the listen gem was required for tests, and needed to be present in the main container and the test container for the tests to pass, so we moved it out of the development group. 

Fixes #159.