### PR TITLE
Added irrelevant kernel CVEs to `.trivyignore`

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,6 @@
+## These vulnerabilities impact the kernel version of the container which
+## isn't used when the code is being run within Docker
+## More info: https://docs.docker.com/engine/security/security/
+CVE-2020-12465
+CVE-2020-12654
+CVE-2020-12659


### PR DESCRIPTION
Since we don't use the included kernel when being run by Docker, these
CVEs are irrelevant to the project so they have been marked as ignored.

Fixes #159 