### PR TITLE
Save artifacts built by CI `master` pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore artifacts
+cyberark-conjur-service-broker_*.zip

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ logfile
 .DS_Store
 bin/buildpack-health-check
 ci/integration/test-app/secrets.yml
+
+# Ignore artifacts
+cyberark-conjur-service-broker_*.zip

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,14 @@ pipeline {
   }
 
   post {
+    success {
+      script {
+        if (env.BRANCH_NAME == 'master') {
+          archiveArtifacts artifacts: '*.zip', fingerprint: true
+        }
+      }
+    }
+
     always {
       cleanupAndNotify(currentBuild.currentResult)
     }


### PR DESCRIPTION
We want to be able to publish the same file that passed tests so this
ensures that Jenkins has it available

Fixes #163 