### PR TITLE
Revert "Bump puma from 3.12.5 to 3.12.6"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,7 +103,7 @@ GEM
       byebug (~> 10.0)
       pry (~> 0.10)
     public_suffix (3.0.2)
-    puma (3.12.6)
+    puma (3.12.5)
     rack (2.0.9)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)


### PR DESCRIPTION
Reverts cyberark/conjur-service-broker#187

In #186 we got the build back to green. There are [issues](https://github.com/puma/puma/issues/2286) with puma 3.12.6 that mean our pipeline fails when we use that version. Let's revert back to 3.12.5 until we can demonstrate that 3.12.6 is working.