### PR TITLE
Add lock to Jenkinsfile to stop collisions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
   options {
     timestamps()
     buildDiscarder(logRotator(numToKeepStr: '30'))
+    lock resource: "conjur-service-broker-build"
   }
 
   triggers {


### PR DESCRIPTION
### What does this PR do?
The service broker is built with a hardcoded "service_id" and "plan_id" in the [catalog](https://github.com/cyberark/conjur-service-broker/blob/master/config/catalog.yml), which means in our e2e tests that deploy the service broker to a remote CF foundation, if two pipelines run at once one may artificially fail because there is already a service broker deployed in the foundation with the same service_id. This commit locks the pipelines so only one can run at once, which may mean pipelines take longer to run, but will help avoid the collision issue until we come up with another solution (such as dynamically updating the service_id in our pipelines).

### What ticket does this PR close?
Connected to #173 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation