### PR TITLE
Return 404 when missing org / space policy branches rather than returning unhelpful 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Service broker returns 404 when the org / space policy branches do not exist
+  as expected with a helpful error message, rather than returning 500.
+  [cyberark/conjur-service-broker#192](https://github.com/cyberark/conjur-service-broker/issues/192)
+
 ## [1.1.2] - 2020-05-15
 
 ### Security

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,10 @@ class ApplicationController < ActionController::API
   rescue_from ServiceBinding::HostNotFound, with: :host_not_found
   rescue_from ServiceBinding::RoleAlreadyCreated, with: :conflict_error
 
+  rescue_from OrgSpacePolicy::OrgPolicyNotFound, with: :policy_not_found
+  rescue_from OrgSpacePolicy::SpacePolicyNotFound, with: :policy_not_found
+  rescue_from OrgSpacePolicy::SpaceLayerNotFound, with: :policy_not_found
+
   rescue_from ValidationError, with: :failed_validation
 
   rescue_from RestClient::Unauthorized, with: :server_error
@@ -61,6 +65,14 @@ class ApplicationController < ActionController::API
   def host_not_found e
     logger.warn(e)
     render json: {}, status: :gone
+  end
+
+  def policy_not_found e
+    logger.warn(e)
+    render json: {
+      error: "PolicyNotFound",
+      description: e
+    }, status: :not_found
   end
 
   def failed_validation e

--- a/app/models/org_space_policy.rb
+++ b/app/models/org_space_policy.rb
@@ -40,7 +40,7 @@ class OrgSpacePolicy
   private
 
   def ensure_org_policy
-    raise OrgPolicyNotFound unless org_policy.exists?
+    raise OrgPolicyNotFound, "Unable to find #{org_policy} policy branch." unless org_policy.exists?
   end
 
   def org_policy
@@ -52,7 +52,7 @@ class OrgSpacePolicy
   end
 
   def ensure_space_policy
-    raise SpacePolicyNotFound unless space_policy.exists?
+    raise SpacePolicyNotFound, "Unable to find #{space_policy} policy branch." unless space_policy.exists?
   end
 
   def space_policy
@@ -64,7 +64,7 @@ class OrgSpacePolicy
   end
 
   def ensure_space_layer
-    raise SpaceLayerNotFound unless space_layer.exists?
+    raise SpaceLayerNotFound, "Unable to find #{space_layer} layer in policy." unless space_layer.exists?
   end
 
   def space_layer

--- a/ci/cf.yml
+++ b/ci/cf.yml
@@ -1,3 +1,26 @@
 - !policy
   id: cf
   owner: !group cf-admin-group
+
+  body:
+  - !policy
+    id: org-policy-without-space-policy
+    body:
+      - !layer
+
+  - !policy
+    id: org-space-policy
+    body:
+      - !layer
+
+      - !policy
+        id: space-policy-without-layer
+
+      - !policy
+        id: space-policy
+        body:
+          - !layer
+
+      - !grant
+        role: !layer
+        member: !layer space-policy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - 8443:443
 
   client:
-    image: conjurinc/cli5
+    image: cyberark/conjur-cli:5
     depends_on: [ conjur_5 ]
     environment:
       CONJUR_APPLIANCE_URL: http://conjur_5

--- a/features/bind.feature
+++ b/features/bind.feature
@@ -1,5 +1,5 @@
 Feature: Binding
-  
+
   Scenario: Bind resource
     When I make a bind request with body:
     """
@@ -237,3 +237,119 @@ Feature: Binding
       "description": "The property '#/plan_id' value \"XXXXXXX-fc8b-496f-a715-e9a1b205d05c.community\" was invalid."
     }
     """
+
+  @conjur-version-5
+  Scenario: Bind resource when org policy branch is missing
+    When I make a bind request with body:
+    """
+    {
+      "context": {
+        "organization_guid": "madeup-org-policy",
+        "space_guid": "space-policy"
+      },
+      "service_id": "c024e536-6dc4-45c6-8a53-127e7f8275ab",
+      "plan_id": "3a116ac2-fc8b-496f-a715-e9a1b205d05c.community",
+      "bind_resource": {
+        "app_guid": "bb841d2b-8287-47a9-ac8f-eef4c16106f8"
+      },
+      "parameters": {
+        "parameter1": 1,
+        "parameter2": "foo"
+      }
+    }
+    """
+    Then the HTTP response status code is "404"
+    And the JSON should be:
+    """
+    {
+      "error": "PolicyNotFound",
+      "description": "Unable to find {\"id\":\"cucumber:policy:cf/madeup-org-policy\"} policy branch."
+    }
+    """
+
+  @conjur-version-5
+  Scenario: Bind resource when space policy branch is missing
+    When I make a bind request with body:
+    """
+    {
+      "context": {
+        "organization_guid": "org-policy-without-space-policy",
+        "space_guid": "missing-space-policy"
+      },
+      "service_id": "c024e536-6dc4-45c6-8a53-127e7f8275ab",
+      "plan_id": "3a116ac2-fc8b-496f-a715-e9a1b205d05c.community",
+      "bind_resource": {
+        "app_guid": "bb841d2b-8287-47a9-ac8f-eef4c16106f8"
+      },
+      "parameters": {
+        "parameter1": 1,
+        "parameter2": "foo"
+      }
+    }
+    """
+    Then the HTTP response status code is "404"
+    And the JSON should be:
+    """
+    {
+      "error": "PolicyNotFound",
+      "description": "Unable to find {\"id\":\"cucumber:policy:cf/org-policy-without-space-policy/missing-space-policy\"} policy branch."
+    }
+    """
+
+  @conjur-version-5
+  Scenario: Bind resource when space layer is missing
+    When I make a bind request with body:
+    """
+    {
+      "context": {
+        "organization_guid": "org-space-policy",
+        "space_guid": "space-policy-without-layer"
+      },
+      "service_id": "c024e536-6dc4-45c6-8a53-127e7f8275ab",
+      "plan_id": "3a116ac2-fc8b-496f-a715-e9a1b205d05c.community",
+      "bind_resource": {
+        "app_guid": "bb841d2b-8287-47a9-ac8f-eef4c16106f8"
+      },
+      "parameters": {
+        "parameter1": 1,
+        "parameter2": "foo"
+      }
+    }
+    """
+    Then the HTTP response status code is "404"
+    And the JSON should be:
+    """
+    {
+      "error": "PolicyNotFound",
+      "description": "Unable to find {\"id\":\"cucumber:layer:cf/org-space-policy/space-policy-without-layer\"} layer in policy."
+    }
+    """
+
+  @conjur-version-5
+  Scenario: Bind resource when valid org / space context is sent
+    When I make a bind request with body:
+    """
+    {
+      "context": {
+        "organization_guid": "org-space-policy",
+        "space_guid": "space-policy"
+      },
+      "service_id": "c024e536-6dc4-45c6-8a53-127e7f8275ab",
+      "plan_id": "3a116ac2-fc8b-496f-a715-e9a1b205d05c.community",
+      "bind_resource": {
+        "app_guid": "bb841d2b-8287-47a9-ac8f-eef4c16106f8"
+      },
+      "parameters": {
+        "parameter1": 1,
+        "parameter2": "foo"
+      }
+    }
+    """
+    Then the HTTP response status code is "201"
+    And the JSON at "credentials/account" should be "cucumber"
+    And the JSON at "credentials/appliance_url" should be the master address
+    And the JSON at "credentials/authn_login" should be a string
+    And the JSON at "credentials/authn_api_key" should be a string
+    And the JSON at "credentials/version" should be a Fixnum
+    And the JSON at "credentials/ssl_certificate" should be a string
+    And the JSON has valid conjur credentials


### PR DESCRIPTION
### What does this PR do?
Updates the service broker to return 404 on bind when the org/space policy branches are missing or on provision when the org/space creation fails.
    
Previously, (as described in #192) if the org / space branches were missing from policy, the bind request would return an unhelpful 500 response.
    
In this PR, we update the service broker to return 404 instead, with an error message that explains what is missing. We also update the Conjur CLI image from the docker-compose to use the updated `cyberark/conjur-cli:5` syntax.

### What ticket does this PR close?
Connected to #192 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [x] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation