### PR TITLE
Default to 5 if CONJUR_VERSION is invalid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- When the value for CONJUR_VERSION is null or empty,
+  we default to `5`. If an invalid value is given,
+  we raise an error immediately.
+  [cyberark/conjur-service-broker#47](https://github.com/cyberark/conjur-service-broker/issues/47)
+
 ## [1.1.3] - 2020-07-17
 
 ### Fixed

--- a/lib/conjur_client.rb
+++ b/lib/conjur_client.rb
@@ -30,7 +30,14 @@ class ConjurClient
     end
 
     def version
-      (ENV['CONJUR_VERSION'] || 5).to_i
+      case ENV['CONJUR_VERSION']
+      when "4"
+        4
+      when "5", "", nil
+        5
+      else
+        raise 'Invalid value for CONJUR_VERSION'
+      end
     end
 
     def account

--- a/spec/lib/conjur_client_spec.rb
+++ b/spec/lib/conjur_client_spec.rb
@@ -125,4 +125,35 @@ describe ConjurClient do
       end
     end
   end
+
+  describe "version" do
+    before do
+      allow(ENV).to receive(:[]).and_call_original
+    end
+
+    it "uses the default version (5) when the input is an empty string" do
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return("")
+      expect(ConjurClient.version).to eq(5)
+    end
+
+    it "uses the default version (5) when the input is empty" do
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION')
+      expect(ConjurClient.version).to eq(5)
+    end
+
+    it "uses the default version (5) when the input is invalid" do
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return("foobar")
+      expect { ConjurClient.version }.to raise_error(RuntimeError)
+    end
+
+    it "uses the given version" do
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return("4")
+      expect(ConjurClient.version).to eq(4)
+    end
+
+    it "uses the given version" do
+      allow(ENV).to receive(:[]).with('CONJUR_VERSION').and_return("5")
+      expect(ConjurClient.version).to eq(5)
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?
Previously, when `version` was called, we would parse the input into an integer. 
If no input was found, we would use `5`. 

However, this does not account for invalid input or empty strings.
This PR implements a simple ternary operator to validate input. 
If "4" is passed in, `4` will be used. Otherwise, we will use `5` as the default.

Spec tests were added to verify functionality 

### What ticket does this PR close?
Connected to #47 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [X] This PR includes new unit and integration tests to go with the code changes, or
- [ ] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation