### PR TITLE
Rack version bump to 2.2.3 in both main and test-app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   we raise an error immediately.
   [cyberark/conjur-service-broker#47](https://github.com/cyberark/conjur-service-broker/issues/47)
 
+### Security
+- Updated rack to v2.2.3 to fix CVE-2020-8184 and CVE-2020-8161
+
 ## [1.1.3] - 2020-07-17
 
 ### Fixed

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'conjur-api', '~> 5.3.1'
 gem 'activesupport', '~> 5.2.4.3'
 gem 'railties', '~> 5.2.4.3'
 gem 'actionview', '~> 5.2.4.2'
-gem 'rack', '~> 2.0.8'
+gem 'rack', '~> 2.2.3'
 gem 'json-schema', '~> 2.8'
 gem 'listen', '>= 3.0.5', '< 3.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -63,7 +63,7 @@ GEM
     gherkin (4.1.3)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.8.3)
+    i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
@@ -104,7 +104,7 @@ GEM
       pry (~> 0.10)
     public_suffix (3.0.2)
     puma (3.12.5)
-    rack (2.0.9)
+    rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails-dom-testing (2.0.3)
@@ -187,7 +187,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   pry-byebug
   puma (~> 3.12)
-  rack (~> 2.0.8)
+  rack (~> 2.2.3)
   railties (~> 5.2.4.3)
   rest-client
   rspec (~> 3)

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -6,21 +6,21 @@ further if you wish to review the copyright notice(s) and the full text
 of the license associated with each component.
 
 
-SECTION 1: Apache-2.0 
+SECTION 1: Apache-2.0
 
 >>> https://rubygems.org/gems/conjur-api/versions/5.3.1
 
-SECTION 2: BSD-3-Clause 
+SECTION 2: BSD-3-Clause
 
 >>> https://rubygems.org/gems/puma/versions/3.12.5
 
-SECTION 3: MIT 
+SECTION 3: MIT
 
 >>> https://rubygems.org/gems/actionview/versions/5.2.4.3
 >>> https://rubygems.org/gems/activesupport/versions/5.2.4.3
 >>> https://rubygems.org/gems/json-schema/versions/2.8.0
 >>> https://rubygems.org/gems/listen/versions/3.1.5
->>> https://rubygems.org/gems/rack/versions/2.0.9
+>>> https://rubygems.org/gems/rack/versions/2.2.3
 >>> https://rubygems.org/gems/railties/versions/5.2.4.3
 
 
@@ -179,7 +179,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
->>> https://rubygems.org/gems/rack/versions/2.0.9
+>>> https://rubygems.org/gems/rack/versions/2.2.3
 
 Copyright (c) 2007-2016 Christian Neukirchen <purl.org/net/chneukirchen>'
 
@@ -483,4 +483,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-

--- a/ci/integration/test-app/Gemfile.lock
+++ b/ci/integration/test-app/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
     minitest (5.10.3)
     mustermann (1.0.3)
     netrc (0.11.0)
-    rack (2.0.8)
+    rack (2.2.3)
     rack-protection (2.0.5)
       rack
     rest-client (2.0.2)


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
Bumps rack in both the main Gemfile/Gemfile.lock and the test-app Gemfile.lock to v2.2.3 to close CVE-2020-8184 and CVE-2020-8161 (neither of which directly impacted us).

### What ticket does this PR close?


### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation