### PR TITLE
Add Conjur v4 deprecation to unreleased changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- When the value for CONJUR_VERSION is null or empty,
-  we default to `5`. If an invalid value is given,
-  we raise an error immediately.
+- When the value for CONJUR_VERSION is null or empty, we default to `5`. If an invalid
+  value is given, we raise an error immediately.
   [cyberark/conjur-service-broker#47](https://github.com/cyberark/conjur-service-broker/issues/47)
+
+### Deprecated
+- Support for using the Conjur Service Broker with Conjur Enterprise v4 is now deprecated.
+  Support will be removed in the next release.
+  [cyberark/conjur-service-broker#191](https://github.com/cyberark/conjur-service-broker/issues/191)
 
 ### Security
 - Updated rack to v2.2.3 to fix CVE-2020-8184 and CVE-2020-8161


### PR DESCRIPTION
### What does this PR do?
In the next release, we'd like to announce deprecation for Conjur Enterprise v4.

### What ticket does this PR close?
Relates to #191

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation