### PR TITLE
Bump Puma version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'json-schema', '~> 2.8'
 gem 'listen', '>= 3.0.5', '< 3.2'
 
 # Use Puma as the app server
-gem 'puma', '3.12.5'
+gem 'puma', '5.1.1'
 
 # Use Rack CORS for handling Cross-Origin Resource Sharing (CORS), making cross-origin AJAX possible
 # gem 'rack-cors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -95,6 +95,7 @@ GEM
     multi_json (1.15.0)
     multi_test (0.1.2)
     netrc (0.11.0)
+    nio4r (2.5.4)
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
@@ -107,7 +108,8 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (3.0.2)
-    puma (3.12.5)
+    puma (5.1.1)
+      nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
     rack-test (1.1.0)
@@ -191,7 +193,7 @@ DEPENDENCIES
   license_finder
   listen (>= 3.0.5, < 3.2)
   pry-byebug
-  puma (= 3.12.5)
+  puma (= 5.1.1)
   rack (~> 2.2.3)
   railties (~> 5.2.4.3)
   rest-client

--- a/features/support/http_helper.rb
+++ b/features/support/http_helper.rb
@@ -5,7 +5,7 @@ module HttpHelper
   end
 
   def headers
-    @headers ||= { 'Content_Type' => 'application/json',
+    @headers ||= { 'Content-Type' => 'application/json',
                    'X-Broker-API-Version'  => '2.13'}
   end
 


### PR DESCRIPTION
### What does this PR do?
- Bumps Puma to 5.1.1
- An issue was found in our tests where we use `Content_Type`, and the
underscore was replaced by a `,`, due to a Puma patch (3.12.6).

Credit to @doodlesbykumbi for figuring out the issue!

### What ticket does this PR close?
Resolves #198 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [X] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation