### PR TITLE
Specify Ruby version in Gemfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   Dynamic Access Provider v11+ or Conjur OSS v1+.
   [cyberark/conjur-service-broker#203](https://github.com/cyberark/conjur-service-broker/issues/203)
 
+### Fixed
+- The service broker Gemfile now specifies the Ruby version so that the service
+  broker no longer fails to install when using a version of the Ruby Buildpack
+  v1.8.15 or older, due to an incompatibility issue between Ruby and Nokogiri
+  versions.
+  [cyberark/conjur-service-broker#229](https://github.com/cyberark/conjur-service-broker/issues/229)
+
 ## [1.1.4] - 2021-01-11
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,12 @@ git_source(:github) do |repo_name|
   "https://github.com/#{repo_name}.git"
 end
 
+# Do not use fuzzy version matching (~>) with the Ruby version. It doesn't play
+# nicely with RVM and we should be explicit since Ruby is such a fundamental
+# part of a Rails project. The Ruby version is also locked in place by the
+# Docker base image so it won't be updated with fuzzy matching.
+ruby '2.5.8'
+
 gem 'conjur-api', '~> 5.3.4'
 gem 'activesupport', '~> 5.2.4.3'
 gem 'railties', '~> 5.2.4.3'


### PR DESCRIPTION
### What does this PR do?
The service broker displays a warning "**WARNING** You have not declared a Ruby version in your Gemfile."

This commit adds the Ruby version (same as Conjur) to the Gemfile so that it is explicit when the service broker
is installed in TAS.

#### Previously

When you install the service broker, you see a warning like:
```
 Downloaded app package (14M)  
              -----&gt; Ruby Buildpack version 1.8.27  
              -----&gt; Supplying Ruby  
              -----&gt; Installing bundler 1.17.3  
                     Copy [/tmp/buildpacks/85b47e8d42f9fa00e609eec0caebf608/dependencies/1b585b3a526373724c47492bbb271365/bundler-1.17.3-any-stack-b7502506.tgz]  
                     [31;1m**WARNING**[0m You have not declared a Ruby version in your Gemfile.  
                     Defaulting to 2.7.2  
                     See http://docs.cloudfoundry.org/buildpacks/ruby/index.html#runtime for more information.  
```

If the Ruby buildpack installed in your TAS foundation is [v1.8.15](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.15) or older, then the default Ruby version is 2.4.x and your service broker installation will actually fail:
```
              2021-01-14T23:04:14.18+0000 [STG/0] OUT        Running: bundle install --without development:test --jobs=4 --retry=4 --path /tmp/contents262779919/deps/0/vendor_bundle --binstubs /tmp/contents262779919/deps/0/binstubs --deployment
              2021-01-14T23:04:15.34+0000 [STG/0] OUT        nokogiri-1.11.1-x86_64-linux requires ruby version &gt;= 2.5, &lt; 3.1.dev, which is
              2021-01-14T23:04:15.34+0000 [STG/0] OUT        incompatible with the current version, ruby 2.4.9p362
              2021-01-14T23:04:15.34+0000 [STG/0] OUT        [31;1m**ERROR**[0m Unable to install gems: exit status 5
              2021-01-14T23:04:15.62+0000 [STG/0] ERR Failed to compile droplet: Failed to run all supply scripts: exit status 15
              2021-01-14T23:04:15.66+0000 [STG/0] OUT Exit status 223
              2021-01-14T23:04:16.10+0000 [STG/0] OUT Cell b5ef2a69-b87f-4049-85d2-0d845352f2b5 stopping instance 550289e5-a7d2-4bde-8ff7-3076c12f7960
              2021-01-14T23:04:16.10+0000 [STG/0] OUT Cell b5ef2a69-b87f-4049-85d2-0d845352f2b5 destroying container for instance 550289e5-a7d2-4bde-8ff7-3076c12f7960
              2021-01-14T23:04:16.19+0000 [API/0] ERR Failed to stage build: staging failed
```

#### After this change
Now it just installs Ruby 2.5.8, which is the version specified in the Gemfile.
```
         -----> Installing bundler 1.17.3
                Copy [/tmp/buildpacks/c1ab4e3fabae331a44e03ee4822ac3df/dependencies/1b585b3a526373724c47492bbb271365/bundler-1.17.3-any-stack-b7502506.tgz]
         -----> Installing ruby 2.5.8
                Copy [/tmp/buildpacks/c1ab4e3fabae331a44e03ee4822ac3df/dependencies/82cdbca8873067bf25b3ea57e40b860a/ruby_2.5.8_linux_x64_cflinuxfs3_3dba0259.tgz]
```

### What ticket does this PR close?
Resolves #229

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation