### PR TITLE
Eliminate UT deprecation warning

### DIFF
--- a/dev/dev_env_menu
+++ b/dev/dev_env_menu
@@ -9,6 +9,9 @@
 # tests can be discovered.
 cd "$(dirname "$0")/.." || (echo "Could not cd to parent dir"; exit 1)
 
+# shellcheck disable=SC1091
+. ./dev/utils.sh
+
 function main_menu() {
 
   local options=( \
@@ -79,6 +82,7 @@ function dry_run() {
 }
 
 function unit_test() {
+  announce "Running RSpec unit tests"
   bundle exec rspec --format RspecJunitFormatter --out spec/reports/test.xml
 }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,12 @@
 require File.expand_path('../../config/environment', __FILE__)
 
 require 'rspec/rails'
+
+RSpec.configure do |config|
+  config.mock_with :rspec do |mocks|
+    mocks.syntax = [:should, :expect]
+  end
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = [:should, :expect]
+  end
+end


### PR DESCRIPTION

### What does this PR do?

When running the service broker UT, a deprecation warning is displayed about the use of
the :should contruct. This adds the explicit configuration so the warning is not displayed.
Below displays the error:
```=====================================================================
Running tests
=====================================================================
1) Run rspec unit tests				     4) Select from a list of Cucumber scenarios to test
2) Run integration (non-E2E) Cucumber tests	     5) Run a bash shell in test container
3) Select from a list of Cucumber features to test   6) Exit and clean up development environment
Please select tests to run: 1
Deprecation Warnings:
Using `stub_chain` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /app/spec/models/service_binding/conjur_v5_app_binding_spec.rb:34:in `block (3 levels) in <top (required)>'.
```

### What ticket does this PR close?
Resolves #222 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation