### PR TITLE
Add vi to the service broker test bash shell.

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -2,7 +2,8 @@ FROM conjur-service-broker
 
 RUN apt-get install -y apt-transport-https \
                        ca-certificates \
-                       openssl
+                       openssl \
+                       vim
 
 # Install the Cloud Foundry CLI
 RUN wget -q https://packages.cloudfoundry.org/debian/cli.cloudfoundry.org.key && \


### PR DESCRIPTION
### What does this PR do?
When we run the service broker bash shell, vi is not installed.
The user must run apt install vim.
This adds vim to the test container.

### What ticket does this PR close?
Resolves #230 

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation