### PR TITLE
Update link in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 - Previously, our ZIP included our test directories, which increased the size of the service broker. 
-  We've introduced a [manifest.txt](./dev/manifest.txt) within the `dev` directory which
-  dictates what will be included in the final ZIP used in our releases and during installation, and allows
-  us to exclude the test directories and developer scripts.
+  We've introduced a [manifest.txt](https://github.com/cyberark/conjur-service-broker/tree/master/dev/manifest.txt)
+  within the `dev` directory which dictates what will be included in the final ZIP used in our
+  releases and during installation, and allows us to exclude the test directories and developer
+  scripts.
   [cyberark/conjur-service-broker#142](https://github.com/cyberark/conjur-service-broker/issues/142)
 
 ### Fixed


### PR DESCRIPTION
### What does this PR do?
Updates link in changelog to be absolute instead of relative, so that downstream release notes aggregation has valid links.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation