### PR TITLE
Pin dev/test Dockerfiles to Ruby 2.5.8 to match Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5.8
 MAINTAINER CyberArk Software Ltd.
 
 RUN apt-get update && \

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5.8
 MAINTAINER CyberArk Software Ltd.
 
 # This is a Dockerfile for the Service Broker image that is used in

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,4 +1,4 @@
-FROM ruby:2.5
+FROM ruby:2.5.8
 MAINTAINER CyberArk Software Ltd.
 
 # This is a Dockerfile for a Service Broker test client image. The repository


### PR DESCRIPTION
### What does this PR do?
The Dockerfile must be pinned to the same version as the Gemfile, otherwise
the build fails in the pipeline.

### What ticket does this PR close?
n/a

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation