### PR TITLE
Upgrade rails packages to 5.2.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Security
+- Updated rails packages (activesupport, railties, actionview) to 5.2.4.6 to resolve CVE-2021-22885
+  [cyberark/conjur-service-broker#241](https://github.com/cyberark/conjur-service-broker/issues/241)
 
 ## [1.1.5] - 2021-03-01
 ### Removed

--- a/Gemfile
+++ b/Gemfile
@@ -12,9 +12,9 @@ end
 ruby '2.5.8'
 
 gem 'conjur-api', '~> 5.3.4'
-gem 'activesupport', '~> 5.2.4.3'
-gem 'railties', '~> 5.2.4.3'
-gem 'actionview', '~> 5.2.4.2'
+gem 'activesupport', '~> 5.2.4.6'
+gem 'railties', '~> 5.2.4.6'
+gem 'actionview', '~> 5.2.4.6'
 gem 'rack', '~> 2.2.3'
 gem 'json-schema', '~> 2.8'
 gem 'listen', '>= 3.0.5', '< 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    actionpack (5.2.4.4)
-      actionview (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    actionpack (5.2.4.6)
+      actionview (= 5.2.4.6)
+      activesupport (= 5.2.4.6)
       rack (~> 2.0, >= 2.0.8)
       rack-test (>= 0.6.3)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.2)
-    actionview (5.2.4.4)
-      activesupport (= 5.2.4.4)
+    actionview (5.2.4.6)
+      activesupport (= 5.2.4.6)
       builder (~> 3.1)
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
-    activesupport (5.2.4.4)
+    activesupport (5.2.4.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -39,7 +39,7 @@ GEM
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     conjur-api (5.3.4)
       activesupport
       rest-client
@@ -65,7 +65,7 @@ GEM
     http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (1.8.7)
+    i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     json-schema (2.8.0)
       addressable (>= 2.4)
@@ -83,23 +83,23 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
-    loofah (2.8.0)
+    loofah (2.9.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2020.1104)
-    mini_portile2 (2.5.0)
-    minitest (5.14.3)
+    mini_portile2 (2.5.1)
+    minitest (5.14.4)
     multi_json (1.15.0)
     multi_test (0.1.2)
     netrc (0.11.0)
     nio4r (2.5.4)
-    nokogiri (1.11.1)
+    nokogiri (1.11.3)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    nokogiri (1.11.1-x86_64-darwin)
+    nokogiri (1.11.3-x86_64-darwin)
       racc (~> 1.4)
     pry (0.13.1)
       coderay (~> 1.1)
@@ -119,9 +119,9 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.3.0)
       loofah (~> 2.3)
-    railties (5.2.4.4)
-      actionpack (= 5.2.4.4)
-      activesupport (= 5.2.4.4)
+    railties (5.2.4.6)
+      actionpack (= 5.2.4.6)
+      activesupport (= 5.2.4.6)
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
@@ -180,8 +180,8 @@ PLATFORMS
   x86_64-darwin-18
 
 DEPENDENCIES
-  actionview (~> 5.2.4.2)
-  activesupport (~> 5.2.4.3)
+  actionview (~> 5.2.4.6)
+  activesupport (~> 5.2.4.6)
   aruba
   bundler-audit
   byebug
@@ -195,13 +195,16 @@ DEPENDENCIES
   pry-byebug
   puma (= 5.1.1)
   rack (~> 2.2.3)
-  railties (~> 5.2.4.3)
+  railties (~> 5.2.4.6)
   rest-client
   rspec (~> 3)
   rspec-rails (~> 3.7)
   rspec_junit_formatter
   spring
   spring-watcher-listen (~> 2.0.0)
+
+RUBY VERSION
+   ruby 2.5.8p224
 
 BUNDLED WITH
    1.17.3

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -16,12 +16,12 @@ SECTION 2: BSD-3-Clause
 
 SECTION 3: MIT
 
->>> https://rubygems.org/gems/actionview/versions/5.2.4.4
->>> https://rubygems.org/gems/activesupport/versions/5.2.4.4
+>>> https://rubygems.org/gems/actionview/versions/5.2.4.6
+>>> https://rubygems.org/gems/activesupport/versions/5.2.4.6
 >>> https://rubygems.org/gems/json-schema/versions/2.8.0
 >>> https://rubygems.org/gems/listen/versions/3.1.5
 >>> https://rubygems.org/gems/rack/versions/2.2.3
->>> https://rubygems.org/gems/railties/versions/5.2.4.4
+>>> https://rubygems.org/gems/railties/versions/5.2.4.6
 
 
 APPENDIX: Standard License Files and Templates


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### What does this PR do?
- Upgrades Rails to 5.2.4.6 to resolve CVE-2021-22885

### What ticket does this PR close?
Resolves #241 

### Checklists

#### Change log
- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [X] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [X] This PR does not require updating any documentation