### PR TITLE
Changelog notes Conjur version required for policy annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 - Service Broker API spec 2.15 and above provide `organization_name` and `space_name`.
   If these are available, they are added as annotations on the organization and space policies
-  that are created in Conjur.
+  that are created in Conjur. Note that this requires Conjur Open Source v1.3.7+ and Conjur
+  Enterprise (formerly Dynamic Access Provider) v11.3.0+; prior to these versions, Conjur
+  did not support adding annotations to policy resources.
   [cyberark/conjur-service-broker#238](https://github.com/cyberark/conjur-service-broker/issues/238)
 
 ### Security


### PR DESCRIPTION
### What does this PR do?
Updates the changelog to be clear that in the new feature added to write org / space name in annotations, it will only work if you are using a version of Conjur that supports annotations on policy resources.

In trying to add an e2e test flow that validates annotations (see the [`integration-test-annotations` branch](https://github.com/cyberark/conjur-service-broker/compare/integration-test-annotations)), I discovered that our older Conjur instance running in AWS (v5.2.3) doesn't support annotations on policy resources.

This was added to `conjur-policy-parser` in [v3.0.3](https://github.com/cyberark/conjur-policy-parser/blob/conjur-oss/CHANGELOG.md#v303), which was included in Conjur Open Source [v1.3.7](https://github.com/cyberark/conjur/blob/master/CHANGELOG.md#137---2019-03-27) and Conjur Enterprise [v5.2.7 / v11.3.0 (private)](https://github.com/conjurinc/appliance/commit/1cb3d2076b831fb3b53b77408182bb265cc7fe41#diff-c00c31ea155bc124459e7069dad860cd2610b6dde8257164007f7bfc89a57f1a).

The changelog message is now clearer on this point.

For what it's worth, I have been able to verify that the service broker _does_ send the policy with annotations in our TAS 2.10 foundation - which confirms that TAS 2.10 sends the human readable org / space names with the provision request AND that the service broker logic handles this correctly. I just unfortunately can't include this in the automation until we upgrade our Conjur instance (planned in conjurinc/cloudfoundry-conjur-tile#55 (private link), when we will move to a local Conjur on the Jenkins executor).

### What ticket does this PR close?
Connected to #238 

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation