### PR TITLE
Update Changelog for Addressable version bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [cyberark/conjur-service-broker#238](https://github.com/cyberark/conjur-service-broker/issues/238)
 
 ### Security
+- Updated addressable to 2.8.0 to resolve GHSA-jxhc-q857-3j6g
+  [cyberark/conjur-service-broker#251](https://github.com/cyberark/conjur-service-broker/pull/251)
 - Updated puma to 5.3.1 to resolve GHSA-q28m-8xjw-8vr5
   [cyberark/conjur-service-broker#246](https://github.com/cyberark/conjur-service-broker/issues/246)
 - Updated nokogiri to 1.11.5 to resolve GHSA-7rrm-v45f-jp64 


### PR DESCRIPTION
### What does this PR do?
Adds a Changelog entry for Addressable version bump from 2.5.2 to 2.8.0.

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation