### PR TITLE
Explicitly specify ruby_buildpack for conjur-service-broker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- The service broker's `./manifest.yml` now explicitly specifies a pinned version of the Ruby Buildpack,
+  [ruby-buildpack.git#v1.8.37](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.37),
+  to ensure the pinned Ruby version in the Gemfile is available when the the service broker is deployed
+  onto TAS foundation.
+  [cyberark/conjur-service-broker#254](https://github.com/cyberark/conjur-service-broker/issues/254)
+
 ## [1.2.0] - 2021-06-09
 ### Added
 - Service Broker API spec 2.15 and above provide `organization_name` and `space_name`.

--- a/manifest.yml
+++ b/manifest.yml
@@ -2,3 +2,5 @@
 applications:
 - name: conjur-service-broker
   command: ./bin/start-service-broker.sh
+  buildpacks:
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.37


### PR DESCRIPTION
### What does this PR do?

The conjur-service-broker is failing to deploy on new releases of the ruby_buildpack (>= v1.8.38), which do not include the pinned Ruby version (2.5.8).

This PR explicitly sets the [ruby_buildpack](https://github.com/cloudfoundry/ruby-buildpack) buildpack to be used when deploying conjur-service-broker. This PR also pins the ruby_buildpack to [ruby-buildpack.git#v1.8.37](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.37) which is the last version to include the pinned Ruby version (2.5.8) for conjur-service-broker.

Ruby 2.5.x versions were removed in [ruby-buildpack.git#v1.8.38](https://github.com/cloudfoundry/ruby-buildpack/releases/tag/v1.8.38)

**NOTES:**

1. Prior to this change the service broker assumed that a buildpack would be autodetected to satisfy the needs of the broker. That meant we didn't need to keep track of where the buildpack came from. Now I'm not sure if it's guaranteed that the cluster can fetch the explicitly stated Ruby buildpack version from Github.

### What ticket does this PR close?
Resolves https://github.com/cyberark/conjur-service-broker/issues/254

### Checklists

#### Change log
- [x] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [x] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [ ] This PR does not require updating any documentation