### PR TITLE
Lock pipeline on tas-infra to avoid contention

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
   options {
     timestamps()
     buildDiscarder(logRotator(numToKeepStr: '30'))
-    lock resource: "conjur-service-broker-build"
+    lock resource: "tas-infra"
   }
 
   triggers {


### PR DESCRIPTION
### What does this PR do?

To avoid conflicts, such as`Service 'cyberark-conjur' is provided by multiple service brokers. Specify a broker by using the '-b' flag.`, it's best to lock the pipeline on "tas-infra" (the standard lock name for our Tanzu infrastructure). This will avoid failure when .e.g. a pipeline for https://github.com/conjurinc/cloudfoundry-conjur-tile is running at the same time.

### What ticket does this PR close?
Resolves -

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation