### PR TITLE
Fixes unknown yaml2 revision build errors

### DIFF
--- a/buildpack-health-check/Dockerfile
+++ b/buildpack-health-check/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12-stretch
+FROM golang:1.15-stretch
 MAINTAINER CyberArk Software, Inc.
 
 ENV GOOS=linux \


### PR DESCRIPTION
### What does this PR do?

Currently, Jenkins builds are failing for the build of the Buildpack Health Check executable, with the following error:

```
[2021-10-15T13:16:37.534Z] go: finding gopkg.in/yaml.v2 v2.2.1
[2021-10-15T13:16:37.795Z] go: gopkg.in/yaml.v2@v2.2.1: unknown revision v2.2.1
[2021-10-15T13:16:39.721Z] go: error loading module requirements
```

This appears to be related to a known bug that used to happen for old versions of Go:
       https://github.com/golang/go/issues/24099
that has since been fixed.

The fix is to use Golang version 1.15 instead of 1.12 for building the Buildpack Health Check executable.

### What ticket does this PR close?

### Checklists

#### Change log
- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a CHANGELOG update

#### Test coverage
- [ ] This PR includes new unit and integration tests to go with the code changes, or
- [x] The changes in this PR do not require tests

#### Documentation
- [ ] Docs (e.g. `README`s) were updated in this PR, and/or there is a follow-on issue to update docs, or
- [x] This PR does not require updating any documentation