### PR TITLE
Update Golang version in health-check Dockerfile

### DIFF
--- a/buildpack-health-check/Dockerfile
+++ b/buildpack-health-check/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-stretch
+FROM golang:1.17-stretch
 MAINTAINER CyberArk Software, Inc.
 
 ENV GOOS=linux \


### PR DESCRIPTION
### Desired Outcome

When we upgraded cyberark/conjur-service-broker's buildpack-health-check to Go 1.17, we didn't update the Dockerfile to use a new base image. Update it to a newer one, both for consistency and Snyk indicates it will reduce the number of known issues in the base.

### Implemented Changes

- Updated golang base image in buildpack-health-check/Dockerfile

### Connected Issue/Story

CyberArk internal issue link: [ONYX-16436](https://ca-il-jira.il.cyber-ark.com:8443/browse/ONYX-16436)

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [x] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [x] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [x] No behavior was changed with this PR

#### Security

- [x] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes 
