### PR TITLE
Ignore IPManager failures

### DIFF
--- a/dev/test_e2e
+++ b/dev/test_e2e
@@ -15,7 +15,11 @@ function cleanup {
   announce "Removing test environment"
   docker-compose down --rmi 'local' --volumes
   if [[ -n "${compute_ip:-}" ]]; then
-    ipmanager remove "${compute_ip}" || true
+    if bl_retry_constant 5 15 ipmanager remove "${compute_ip}"; then
+      echo "Removed TAS Compute  IP from IPManager"
+    else
+      echo "Failed to remove TAS Compute IP From IPManager. Not a problem it will expire out of the prefix list soon."
+    fi
   fi
 }
 trap cleanup EXIT


### PR DESCRIPTION
Builds shouldn't fail on IPManager cleanup. This commit ignores
failures from IPManager when cleaning up. This is OK because the
IPs are added to IPManager with a 2 hour expiry time, so they'll
be cleaned up soon even if the cleanup during the build fails.

Related: conjurinc/ops#879