### PR TITLE
Remove Stderr redirect from Cert Fetch

### DIFF
--- a/dev/test_e2e
+++ b/dev/test_e2e
@@ -118,7 +118,7 @@ function getConjurSSLCert() {
   hostname="${PCF_CONJUR_APPLIANCE_URL//http[s]*:\/\//}"
   # Get the Conjur SSL CA certificate chain
   PCF_CONJUR_SSL_CERT="$(openssl s_client -showcerts \
-    -connect "$hostname":443 </dev/null 2>/dev/null \
+    -connect "$hostname":443 </dev/null \
     | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p')"
   export PCF_CONJUR_SSL_CERT
   echo "Done"


### PR DESCRIPTION
This hides any errors that occur on this step.
The redirect is removed so that errors will be shown in future builds.