### PR TITLE
Pin TAS to 2.13

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -72,7 +72,7 @@ pipeline {
     // 'docker-compose down ...'.
     stage('End-to-End Testing') {
       steps {
-        allocateTas()
+        allocateTas('isv_ci_tas_srt_2_13')
         sh 'cd dev && summon ./test_e2e'
         junit 'features/reports/**/*.xml, spec/reports/*.xml'
       }


### PR DESCRIPTION
TAS V3 is causing problems, this commit is to pin back to latest 2.x so work can continue. V3 compatibility will be a separate effort.

Related: ONYX-26801