### PR TITLE
Update conjur-api-go to v0.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Security
+- Update conjur-api-go to v0.10.2 to udpate indirect dependency gopkg.in/yaml.v2
+  [cyberark/conjur-service-broker#305](https://github.com/cyberark/conjur-service-broker/pull/305)
 - Update loofah to 2.19.1 for CVE-2022-23514, CVE-2022-23515 and CVE-2022-23516 (all Not Vulnerable)
   and rails-html-sanitizr to 1.4.4 for CVE-2022-23517, CVE-2022-23518, CVE-2022-23519, and CVE-2022-23520 (Not vulnerable)
   [cyberark/conjur-service-broker#304](https://github.com/cyberark/conjur-service-broker/pull/304)

--- a/buildpack-health-check/go.mod
+++ b/buildpack-health-check/go.mod
@@ -2,7 +2,7 @@ module github.com/cyberark/conjur-service-broker/buildpack-health-check
 
 go 1.17
 
-require github.com/cyberark/conjur-api-go v0.10.1
+require github.com/cyberark/conjur-api-go v0.10.2
 
 require (
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect

--- a/buildpack-health-check/go.sum
+++ b/buildpack-health-check/go.sum
@@ -1,7 +1,7 @@
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d h1:xDfNPAt8lFiC1UJrqV3uuy861HCTo708pDMbjHHdCas=
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
-github.com/cyberark/conjur-api-go v0.10.1 h1:3gaKBINNyz9KGaY8SWatODVziINHYVmz+uAXKYujwIA=
-github.com/cyberark/conjur-api-go v0.10.1/go.mod h1:8+qYC7L6wPY1e56hoZmHSdGa2fHALck8PtS+cUky75Y=
+github.com/cyberark/conjur-api-go v0.10.2 h1:V2zip069ybE1ubAi2xsay4WGdXG4vIQZ1z7GXPRt7IY=
+github.com/cyberark/conjur-api-go v0.10.2/go.mod h1:8+qYC7L6wPY1e56hoZmHSdGa2fHALck8PtS+cUky75Y=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Signed-off-by: Andy Tinkham <andy.tinkham@cyberark.com>

### Desired Outcome

Remove indirect dependency gopkg.in/yaml.v2 versions less than / equal to 2.2.4

### Implemented Changes

Updated conjur-api-go version to 0.10.2