### PR TITLE
Remove no longer needed CVE protections

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,3 @@
 .codeclimate.yml @cyberark/quality-architects
 # Changes to SECURITY.md require Security Architect approval
 SECURITY.md @cyberark/security-architects
-
-# Need to make sure we don't add something that triggers CVE-2020-36327 or CVE-2021-43809
-Gemfile* @cyberark/security-architects

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,11 +1,3 @@
-# At the moment, we do not pull any private gems. Updating to 
-# a fixed version of bundler requires updating the whole project to Ruby
-# 3.0, which breaks the tests. CONJSE-1571 is entered for this upgrade 
-# process. For now, ignore the bundler CVEs since we don't trigger them
-# but we need to check it if we change the Gemfile.
-CVE-2020-36327
-CVE-2021-43809
-
 # These vulnerabilities impact the kernel version of the container which
 ## isn't used when the code is being run within Docker
 ## More info: https://docs.docker.com/engine/security/security/


### PR DESCRIPTION
### Desired Outcome

Now that this project has been upgraded to Ruby 3.1, we don't need the bits we put in place to make sure we didn't fall victim to some bundler CVEs. Clean them up.

### Implemented Changes

- Removed the CODEOWNERS entry for Gemfile and Gemfile.lock that required security architects review on changes
- Removed the .trivyignore for the CVEs

