### PR TITLE
Upgrade rack from 2.2.6.2 to 2.2.6.3 to resolve CVE-2023-27530

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [1.2.8] - 2023-03-02
+## [1.2.8] - 2023-03-14
 ### Changed
 - Upgrade supported Ruby version to 3.1.x. Resolves CVE-2021-33621, CVE-2020-36327 and CVE-2021-43809
   [cyberark/conjur-service-broker#306](https://github.com/cyberark/conjur-service-broker/pull/306)
 
 ### Security
+- Update rack in Gemfile.lock and tests/integration/test-app/Gemfile.lock to 2.2.6.3
+  for CVE-2023-27630 (not vulnerable)
+  [cyberark/conjur-service-broker#320](https://github.com/cyberark/conjur-service-broker/pull/320)
 - Update activesupport in Gemfile.lock to 6.1.7.2 for CVE-2023-22796 (not vulnerable)
   [cyberark/conjur-service-broker#312](https://github.com/cyberark/conjur-service-broker/pull/312)
 - Update activesupport in tests/integration/test-app/Gemfile.lock to 7.0.4.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
     puma (5.6.4)
       nio4r (~> 2.0)
     racc (1.6.2)
-    rack (2.2.6.2)
+    rack (2.2.6.3)
     rack-test (2.0.2)
       rack (>= 1.3)
     rails-dom-testing (2.0.3)

--- a/NOTICES.txt
+++ b/NOTICES.txt
@@ -20,7 +20,7 @@ SECTION 3: MIT
 >>> https://rubygems.org/gems/activesupport/versions/6.1.7.2
 >>> https://rubygems.org/gems/json-schema/versions/2.8.0
 >>> https://rubygems.org/gems/listen/versions/3.0.8
->>> https://rubygems.org/gems/rack/versions/2.2.6.2
+>>> https://rubygems.org/gems/rack/versions/2.2.6.3
 >>> https://rubygems.org/gems/railties/versions/6.1.7.2
 
 
@@ -178,7 +178,7 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
->>> https://rubygems.org/gems/rack/versions/2.2.6.2
+>>> https://rubygems.org/gems/rack/versions/2.2.6.3
 
 Copyright (c) 2007-2021 Leah Neukirchen <http://leahneukirchen.org/infopage.html>
 

--- a/tests/integration/test-app/Gemfile.lock
+++ b/tests/integration/test-app/Gemfile.lock
@@ -43,7 +43,7 @@ GEM
       ruby2_keywords (~> 0.0.1)
     netrc (0.11.0)
     public_suffix (5.0.1)
-    rack (2.2.6.2)
+    rack (2.2.6.3)
     rack-protection (3.0.5)
       rack
     rest-client (2.1.0)


### PR DESCRIPTION
### Desired Outcome

This pull request upgrades 'rack' from 2.2.6.2 to 3.0.4.2 to resolve security issue CVE-2023-27630.

### Implemented Changes

- Upgraded rack in Gemfile.lock
- Upgraded rack in tests/integration/test-app/Gemfile.lock
- Updated NOTICES.txt
- Updated CHANGELOG.md

#### Changelog

- [X] The CHANGELOG has been updated, or
- [ ] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [X] These changes are part of a larger initiative that will be reviewed later, or
- [ ] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [X] These changes are part of a larger initiative with a separate security review, or
- [ ] There are no security aspects to these changes
